### PR TITLE
chore: update gcp-metadata to pick up fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1114,9 +1114,9 @@
       "dev": true
     },
     "gcp-metadata": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.6.3.tgz",
-      "integrity": "sha512-MSmczZctbz91AxCvqp9GHBoZOSbJKAICV7Ow/AIWSJZRrRchUd5NL1b2P4OfP+4m490BEUPhhARfpHdqCxuCvg==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.6.5.tgz",
+      "integrity": "sha512-E+mNkunv+z3OmnZ8ZOy2CpwKUcXl/2gdDUT4TIfNIb6NOnKzoooxV/RIl+WuFKoIOgWAst5kiQ7O3rTpw4kkUw==",
       "requires": {
         "axios": "^0.18.0",
         "extend": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
   ],
   "dependencies": {
     "axios": "^0.18.0",
+    "gcp-metadata": "^0.6.5",
     "gtoken": "^2.3.0",
     "jws": "^3.1.5",
     "lodash.isstring": "^4.0.1",
     "lru-cache": "^4.1.3",
-    "retry-axios": "^0.3.2",
-    "gcp-metadata": "^0.6.3"
+    "retry-axios": "^0.3.2"
   },
   "devDependencies": {
     "@justinbeckwith/typedoc": "^0.10.1",


### PR DESCRIPTION
gcp-metadata no longer swallows unexpected errors.
Refs: stephenplusplus/gcp-metadata#57