### PR TITLE
fix: export additional typescript types

### DIFF
--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -114,8 +114,7 @@ export interface TokenInfo {
   access_type?: string;
 }
 
-
-export interface TokenInfoRequest {
+interface TokenInfoRequest {
   aud: string;
   user_id?: string;
   scope: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,13 +16,13 @@
 import {GoogleAuth} from './auth/googleauth';
 
 export {Compute, ComputeOptions} from './auth/computeclient';
-export {Credentials} from './auth/credentials';
+export {CredentialBody, CredentialRequest, Credentials, JWTInput} from './auth/credentials';
 export {GoogleAuthOptions} from './auth/googleauth';
-export {IAMAuth} from './auth/iam';
-export {JWTAccess} from './auth/jwtaccess';
-export {JWT} from './auth/jwtclient';
-export {CodeChallengeMethod, OAuth2Client} from './auth/oauth2client';
-export {UserRefreshClient} from './auth/refreshclient';
+export {IAMAuth, RequestMetadata} from './auth/iam';
+export {Claims, JWTAccess} from './auth/jwtaccess';
+export {JWT, JWTOptions} from './auth/jwtclient';
+export {Certificates, CodeChallengeMethod, GenerateAuthUrlOpts, GetTokenOptions, OAuth2Client, OAuth2ClientOptions, RefreshOptions, TokenInfo, VerifyIdTokenOptions} from './auth/oauth2client';
+export {UserRefreshClient, UserRefreshClientOptions} from './auth/refreshclient';
 export {DefaultTransporter} from './transporters';
 
 const auth = new GoogleAuth();


### PR DESCRIPTION
I noticed that you're having to reach into files for types.  I should export them :)
https://github.com/googleapis/cloud-trace-nodejs/pull/871/files