### PR TITLE
fix: use faster gcloud command to retrieve projectId

### DIFF
--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -560,21 +560,18 @@ export class GoogleAuth {
    */
   private async getDefaultServiceProjectId(): Promise<string|null> {
     return new Promise<string|null>(resolve => {
-      exec(
-          'gcloud config config-helper --format json',
-          (err, stdout, stderr) => {
-            if (!err && stdout) {
-              try {
-                const projectId =
-                    JSON.parse(stdout).configuration.properties.core.project;
-                resolve(projectId);
-                return;
-              } catch (e) {
-                // ignore errors
-              }
-            }
-            resolve(null);
-          });
+      exec('gcloud config get-value project', (err, stdout, stderr) => {
+        if (!err && stdout) {
+          try {
+            const projectId = stdout.trim();
+            resolve(projectId);
+            return;
+          } catch (e) {
+            // ignore errors
+          }
+        }
+        resolve(null);
+      });
     });
   }
 

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -784,8 +784,7 @@ it('getProjectId should use Cloud SDK when it is available and env vars are not 
      // * Well-known file is set up to point to private2.json
      // * Running on GCE is set to true.
      blockGoogleApplicationCredentialEnvironmentVariable();
-     const stdout = JSON.stringify(
-         {configuration: {properties: {core: {project: fixedProjectId}}}});
+     const stdout = fixedProjectId;
      const stub = sandbox.stub(child_process, 'exec')
                       .callsArgWith(1, null, stdout, null);
      const projectId = await auth.getProjectId();


### PR DESCRIPTION
Fixes #484

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Change gcloud command to retrieve projectId with a faster one