### PR TITLE
fix(types): export GCPEnv type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {GoogleAuth} from './auth/googleauth';
 
 export {Compute, ComputeOptions} from './auth/computeclient';
 export {CredentialBody, CredentialRequest, Credentials, JWTInput} from './auth/credentials';
+export {GCPEnv} from './auth/envDetect';
 export {GoogleAuthOptions} from './auth/googleauth';
 export {IAMAuth, RequestMetadata} from './auth/iam';
 export {Claims, JWTAccess} from './auth/jwtaccess';
@@ -24,7 +25,6 @@ export {JWT, JWTOptions} from './auth/jwtclient';
 export {Certificates, CodeChallengeMethod, GenerateAuthUrlOpts, GetTokenOptions, OAuth2Client, OAuth2ClientOptions, RefreshOptions, TokenInfo, VerifyIdTokenOptions} from './auth/oauth2client';
 export {UserRefreshClient, UserRefreshClientOptions} from './auth/refreshclient';
 export {DefaultTransporter} from './transporters';
-export {GCPEnv} from './auth/envDetect';
 
 const auth = new GoogleAuth();
 export {auth, GoogleAuth};

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export {JWT, JWTOptions} from './auth/jwtclient';
 export {Certificates, CodeChallengeMethod, GenerateAuthUrlOpts, GetTokenOptions, OAuth2Client, OAuth2ClientOptions, RefreshOptions, TokenInfo, VerifyIdTokenOptions} from './auth/oauth2client';
 export {UserRefreshClient, UserRefreshClientOptions} from './auth/refreshclient';
 export {DefaultTransporter} from './transporters';
+export {GCPEnv} from './auth/envDetect';
 
 const auth = new GoogleAuth();
 export {auth, GoogleAuth};


### PR DESCRIPTION
It would be good if users could refer to `GCPEnv` enumeration directly.
