### PR TITLE
build: add browser test running on Kokoro

### DIFF
--- a/.kokoro/browser-test.sh
+++ b/.kokoro/browser-test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -xeo pipefail
+
+export NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+# Setup service account credentials.
+export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/service-account.json
+export GCLOUD_PROJECT=long-door-651
+
+cd $(dirname $0)/..
+
+npm install
+
+npm run browser-test

--- a/.kokoro/continuous/node8/browser-test.cfg
+++ b/.kokoro/continuous/node8/browser-test.cfg
@@ -1,0 +1,7 @@
+# Download resources for system tests (service account key, etc.)
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/google-cloud-nodejs"
+
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/google-auth-library-nodejs/.kokoro/browser-test.sh"
+}

--- a/.kokoro/presubmit/node8/browser-test.cfg
+++ b/.kokoro/presubmit/node8/browser-test.cfg
@@ -1,0 +1,7 @@
+# Download resources for system tests (service account key, etc.)
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/google-cloud-nodejs"
+
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/google-auth-library-nodejs/.kokoro/browser-test.sh"
+}


### PR DESCRIPTION
do not merge until `browser test` shows up in checks.