### PR TITLE
fix(deps): upgrade to gcp-metadata v0.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "axios": "^0.18.0",
     "base64-js": "^1.3.0",
     "fast-text-encoding": "^1.0.0",
-    "gcp-metadata": "^0.7.0",
+    "gcp-metadata": "^0.9.3",
     "gtoken": "^2.3.0",
     "https-proxy-agent": "^2.2.1",
     "jws": "^3.1.5",

--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -66,21 +66,20 @@ export class Compute extends OAuth2Client {
   protected async refreshTokenNoCache(refreshToken?: string|
                                       null): Promise<GetTokenResponse> {
     const tokenPath = `service-accounts/${this.serviceAccountEmail}/token`;
-    let res: AxiosResponse<CredentialRequest>;
+    let data: CredentialRequest;
     try {
-      res = await gcpMetadata.instance(tokenPath);
+      data = await gcpMetadata.instance(tokenPath);
     } catch (e) {
       e.message = 'Could not refresh access token.';
       throw e;
     }
-    const tokens = res.data as Credentials;
-    if (res.data && res.data.expires_in) {
-      tokens.expiry_date =
-          ((new Date()).getTime() + (res.data.expires_in * 1000));
+    const tokens = data as Credentials;
+    if (data && data.expires_in) {
+      tokens.expiry_date = ((new Date()).getTime() + (data.expires_in * 1000));
       delete (tokens as CredentialRequest).expires_in;
     }
     this.emit('tokens', tokens);
-    return {tokens, res};
+    return {tokens, res: null};
   }
 
   protected requestAsync<T>(opts: AxiosRequestConfig, retry = false):

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -610,7 +610,7 @@ export class GoogleAuth {
   private async getGCEProjectId() {
     try {
       const r = await gcpMetadata.project('project-id');
-      return r.data;
+      return r;
     } catch (e) {
       // Ignore any errors
       return null;
@@ -658,8 +658,8 @@ export class GoogleAuth {
     // NOTE: The trailing '/' at the end of service-accounts/ is very important!
     // The GCF metadata server doesn't respect querystring params if this / is
     // not included.
-    const {data} = await gcpMetadata.instance(
-        {property: 'service-accounts/', params: {recursive: true}});
+    const data = await gcpMetadata.instance(
+        {property: 'service-accounts/', params: {recursive: 'true'}});
 
     if (!data || !data.default || !data.default.email) {
       throw new Error('Failure from metadata server.');


### PR DESCRIPTION
BREAKING CHANGE: In cases where the `Compute` client is used, the the `getRequestHeaders` method will no longer return an `AxiosResponse` object if a request is made to the metadata server.  The value of the object will return null. This is not likely to affect any downstream APIs, but is a breaking change nonetheless.

NOTE: This was already approved in https://github.com/googleapis/google-auth-library-nodejs/pull/536