### PR TITLE
fix: no jsonp support

### DIFF
--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -736,15 +736,9 @@ export class OAuth2Client extends AuthClient {
   /**
    * Generates an URL to revoke the given token.
    * @param token The existing token to be revoked.
-   * @param jsonp If set, append callback= parameter to request JSONP response.
    */
-  static getRevokeTokenUrl(token: string, jsonp?: string): string {
-    let parameters = '';
-    if (jsonp) {
-      parameters = querystring.stringify({token, 'callback': jsonp});
-    } else {
-      parameters = querystring.stringify({token});
-    }
+  static getRevokeTokenUrl(token: string): string {
+    const parameters = querystring.stringify({token});
     return `${OAuth2Client.GOOGLE_OAUTH2_REVOKE_URL_}?${parameters}`;
   }
 


### PR DESCRIPTION
Browser stuff again here. The new endpoint for `revoke` introduced for #434 supports only POST, and does not support JSONP, so we don't need this.
