### PR TITLE
refactor(deps): use `gaxios` for HTTP requests instead of `axios`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "base64-js": "^1.3.0",
     "fast-text-encoding": "^1.0.0",
-    "gaxios": "^1.1.0",
+    "gaxios": "^1.1.1",
     "gcp-metadata": "^0.9.3",
     "gtoken": "^2.3.2",
     "https-proxy-agent": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "client library"
   ],
   "dependencies": {
-    "axios": "^0.18.0",
     "base64-js": "^1.3.0",
     "fast-text-encoding": "^1.0.0",
+    "gaxios": "^1.1.0",
     "gcp-metadata": "^0.9.3",
     "gtoken": "^2.3.2",
     "https-proxy-agent": "^2.2.1",

--- a/src/auth/authclient.ts
+++ b/src/auth/authclient.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {AxiosPromise, AxiosRequestConfig} from 'axios';
 import {EventEmitter} from 'events';
+import {GaxiosOptions, GaxiosPromise} from 'gaxios';
 
 import {DefaultTransporter} from '../transporters';
 
@@ -30,9 +30,9 @@ export abstract class AuthClient extends EventEmitter {
   credentials: Credentials = {};
 
   /**
-   * Provides an alternative Axios request implementation with auth credentials
+   * Provides an alternative Gaxios request implementation with auth credentials
    */
-  abstract request<T>(opts: AxiosRequestConfig): AxiosPromise<T>;
+  abstract request<T>(opts: GaxiosOptions): GaxiosPromise<T>;
 
   /**
    * Sets the auth credentials.

--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AxiosError, AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios';
+import {GaxiosError, GaxiosOptions, GaxiosPromise} from 'gaxios';
 import * as gcpMetadata from 'gcp-metadata';
 import * as messages from '../messages';
 import {CredentialRequest, Credentials} from './credentials';
@@ -82,10 +82,10 @@ export class Compute extends OAuth2Client {
     return {tokens, res: null};
   }
 
-  protected requestAsync<T>(opts: AxiosRequestConfig, retry = false):
-      AxiosPromise<T> {
+  protected requestAsync<T>(opts: GaxiosOptions, retry = false):
+      GaxiosPromise<T> {
     return super.requestAsync<T>(opts, retry).catch(e => {
-      const res = (e as AxiosError).response;
+      const res = (e as GaxiosError).response;
       if (res && res.status) {
         let helpfulMessage = null;
         if (res.status === 403) {

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {GaxiosOptions, GaxiosResponse} from 'gaxios';
 import {exec} from 'child_process';
 import * as fs from 'fs';
+import {GaxiosOptions, GaxiosResponse} from 'gaxios';
 import * as gcpMetadata from 'gcp-metadata';
 import * as os from 'os';
 import * as path from 'path';

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AxiosRequestConfig, AxiosResponse} from 'axios';
+import {GaxiosOptions, GaxiosResponse} from 'gaxios';
 import {exec} from 'child_process';
 import * as fs from 'fs';
 import * as gcpMetadata from 'gcp-metadata';
@@ -732,7 +732,7 @@ export class GoogleAuth {
    * @param opts Axios request options for the HTTP request.
    */
   // tslint:disable-next-line no-any
-  async request<T = any>(opts: AxiosRequestConfig): Promise<AxiosResponse<T>> {
+  async request<T = any>(opts: GaxiosOptions): Promise<GaxiosResponse<T>> {
     const client = await this.getClient();
     return client.request<T>(opts);
   }

--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AxiosError, AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios';
+import {GaxiosError, GaxiosOptions, GaxiosPromise, GaxiosResponse} from 'gaxios';
 import * as querystring from 'querystring';
 import * as stream from 'stream';
 
@@ -264,53 +264,53 @@ export interface GenerateAuthUrlOpts {
 }
 
 export interface GetTokenCallback {
-  (err: AxiosError|null, token?: Credentials|null,
-   res?: AxiosResponse|null): void;
+  (err: GaxiosError|null, token?: Credentials|null,
+   res?: GaxiosResponse|null): void;
 }
 
 export interface GetTokenResponse {
   tokens: Credentials;
-  res: AxiosResponse|null;
+  res: GaxiosResponse|null;
 }
 
 export interface GetAccessTokenCallback {
-  (err: AxiosError|null, token?: string|null, res?: AxiosResponse|null): void;
+  (err: GaxiosError|null, token?: string|null, res?: GaxiosResponse|null): void;
 }
 
 export interface GetAccessTokenResponse {
   token?: string|null;
-  res?: AxiosResponse|null;
+  res?: GaxiosResponse|null;
 }
 
 export interface RefreshAccessTokenCallback {
-  (err: AxiosError|null, credentials?: Credentials|null,
-   res?: AxiosResponse|null): void;
+  (err: GaxiosError|null, credentials?: Credentials|null,
+   res?: GaxiosResponse|null): void;
 }
 
 export interface RefreshAccessTokenResponse {
   credentials: Credentials;
-  res: AxiosResponse|null;
+  res: GaxiosResponse|null;
 }
 
 export interface RequestMetadataResponse {
   headers: Headers;
-  res?: AxiosResponse<void>|null;
+  res?: GaxiosResponse<void>|null;
 }
 
 export interface RequestMetadataCallback {
-  (err: AxiosError|null, headers?: Headers,
-   res?: AxiosResponse<void>|null): void;
+  (err: GaxiosError|null, headers?: Headers,
+   res?: GaxiosResponse<void>|null): void;
 }
 
 export interface GetFederatedSignonCertsCallback {
-  (err: AxiosError|null, certs?: Certificates,
-   response?: AxiosResponse<void>|null): void;
+  (err: GaxiosError|null, certs?: Certificates,
+   response?: GaxiosResponse<void>|null): void;
 }
 
 export interface FederatedSignonCertsResponse {
   certs: Certificates;
   format: CertificateFormat;
-  res?: AxiosResponse<void>|null;
+  res?: GaxiosResponse<void>|null;
 }
 
 export interface RevokeCredentialsResult {
@@ -715,7 +715,7 @@ export class OAuth2Client extends AuthClient {
       r = await this.refreshToken(thisCreds.refresh_token);
       tokens = r.tokens;
     } catch (err) {
-      const e = err as AxiosError;
+      const e = err as GaxiosError;
       if (e.response &&
           (e.response.status === 403 || e.response.status === 404)) {
         e.message = 'Could not refresh access token.';
@@ -747,14 +747,14 @@ export class OAuth2Client extends AuthClient {
    * @param token The existing token to be revoked.
    * @param callback Optional callback fn.
    */
-  revokeToken(token: string): AxiosPromise<RevokeCredentialsResult>;
+  revokeToken(token: string): GaxiosPromise<RevokeCredentialsResult>;
   revokeToken(
       token: string,
       callback: BodyResponseCallback<RevokeCredentialsResult>): void;
   revokeToken(
       token: string, callback?: BodyResponseCallback<RevokeCredentialsResult>):
-      AxiosPromise<RevokeCredentialsResult>|void {
-    const opts = {url: OAuth2Client.getRevokeTokenUrl(token), method: 'POST'};
+      GaxiosPromise<RevokeCredentialsResult>|void {
+    const opts: GaxiosOptions = {url: OAuth2Client.getRevokeTokenUrl(token), method: 'POST'};
     if (callback) {
       this.transporter.request<RevokeCredentialsResult>(opts).then(
           r => callback(null, r), callback);
@@ -768,11 +768,11 @@ export class OAuth2Client extends AuthClient {
    * Revokes access token and clears the credentials object
    * @param callback callback
    */
-  revokeCredentials(): AxiosPromise<RevokeCredentialsResult>;
+  revokeCredentials(): GaxiosPromise<RevokeCredentialsResult>;
   revokeCredentials(callback: BodyResponseCallback<RevokeCredentialsResult>):
       void;
   revokeCredentials(callback?: BodyResponseCallback<RevokeCredentialsResult>):
-      AxiosPromise<RevokeCredentialsResult>|void {
+      GaxiosPromise<RevokeCredentialsResult>|void {
     if (callback) {
       this.revokeCredentialsAsync().then(res => callback(null, res), callback);
     } else {
@@ -798,10 +798,10 @@ export class OAuth2Client extends AuthClient {
    * @param callback callback.
    * @return Request object
    */
-  request<T>(opts: AxiosRequestConfig): AxiosPromise<T>;
-  request<T>(opts: AxiosRequestConfig, callback: BodyResponseCallback<T>): void;
-  request<T>(opts: AxiosRequestConfig, callback?: BodyResponseCallback<T>):
-      AxiosPromise<T>|void {
+  request<T>(opts: GaxiosOptions): GaxiosPromise<T>;
+  request<T>(opts: GaxiosOptions, callback: BodyResponseCallback<T>): void;
+  request<T>(opts: GaxiosOptions, callback?: BodyResponseCallback<T>):
+      GaxiosPromise<T>|void {
     if (callback) {
       this.requestAsync<T>(opts).then(r => callback(null, r), e => {
         return callback(e, e.response);
@@ -811,9 +811,9 @@ export class OAuth2Client extends AuthClient {
     }
   }
 
-  protected async requestAsync<T>(opts: AxiosRequestConfig, retry = false):
-      Promise<AxiosResponse<T>> {
-    let r2: AxiosResponse;
+  protected async requestAsync<T>(opts: GaxiosOptions, retry = false):
+      Promise<GaxiosResponse<T>> {
+    let r2: GaxiosResponse;
     try {
       const r = await this.getRequestMetadataAsync(opts.url);
       if (r.headers && r.headers.Authorization) {
@@ -826,7 +826,7 @@ export class OAuth2Client extends AuthClient {
       }
       r2 = await this.transporter.request<T>(opts);
     } catch (e) {
-      const res = (e as AxiosError).response;
+      const res = (e as GaxiosError).response;
       if (res) {
         const statusCode = res.status;
         // Retry the request for metadata if the following criteria are true:
@@ -944,7 +944,7 @@ export class OAuth2Client extends AuthClient {
         this.certificateCacheFormat === format) {
       return {certs: this.certificateCache, format};
     }
-    let res: AxiosResponse;
+    let res: GaxiosResponse;
     let url: string;
     switch (format) {
       case CertificateFormat.PEM:

--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -754,7 +754,10 @@ export class OAuth2Client extends AuthClient {
   revokeToken(
       token: string, callback?: BodyResponseCallback<RevokeCredentialsResult>):
       GaxiosPromise<RevokeCredentialsResult>|void {
-    const opts: GaxiosOptions = {url: OAuth2Client.getRevokeTokenUrl(token), method: 'POST'};
+    const opts: GaxiosOptions = {
+      url: OAuth2Client.getRevokeTokenUrl(token),
+      method: 'POST'
+    };
     if (callback) {
       this.transporter.request<RevokeCredentialsResult>(opts).then(
           r => callback(null, r), callback);

--- a/src/transporters.ts
+++ b/src/transporters.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {GaxiosError, GaxiosPromise, GaxiosOptions, GaxiosResponse, request} from 'gaxios';
+import {GaxiosError, GaxiosOptions, GaxiosPromise, GaxiosResponse, request} from 'gaxios';
 
 import {isBrowser} from './isbrowser';
 import {validate} from './options';
@@ -25,8 +25,7 @@ const PRODUCT_NAME = 'google-api-nodejs-client';
 
 export interface Transporter {
   request<T>(opts: GaxiosOptions): GaxiosPromise<T>;
-  request<T>(opts: GaxiosOptions, callback?: BodyResponseCallback<T>):
-      void;
+  request<T>(opts: GaxiosOptions, callback?: BodyResponseCallback<T>): void;
   request<T>(opts: GaxiosOptions, callback?: BodyResponseCallback<T>):
       GaxiosPromise|void;
 }
@@ -73,8 +72,7 @@ export class DefaultTransporter {
    * @return GaxiosPromise, assuming no callback is passed.
    */
   request<T>(opts: GaxiosOptions): GaxiosPromise<T>;
-  request<T>(opts: GaxiosOptions, callback?: BodyResponseCallback<T>):
-      void;
+  request<T>(opts: GaxiosOptions, callback?: BodyResponseCallback<T>): void;
   request<T>(opts: GaxiosOptions, callback?: BodyResponseCallback<T>):
       GaxiosPromise|void {
     // ensure the user isn't passing in request-style options

--- a/src/transporters.ts
+++ b/src/transporters.ts
@@ -14,43 +14,31 @@
  * limitations under the License.
  */
 
-import axios, {AxiosError, AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios';
+import {GaxiosError, GaxiosPromise, GaxiosOptions, GaxiosResponse, request} from 'gaxios';
 
 import {isBrowser} from './isbrowser';
 import {validate} from './options';
-
-// tslint:disable-next-line variable-name
-const HttpsProxyAgent = require('https-proxy-agent');
 
 // tslint:disable-next-line no-var-requires
 const pkg = require('../../package.json');
 const PRODUCT_NAME = 'google-api-nodejs-client';
 
 export interface Transporter {
-  request<T>(opts: AxiosRequestConfig): AxiosPromise<T>;
-  request<T>(opts: AxiosRequestConfig, callback?: BodyResponseCallback<T>):
+  request<T>(opts: GaxiosOptions): GaxiosPromise<T>;
+  request<T>(opts: GaxiosOptions, callback?: BodyResponseCallback<T>):
       void;
-  request<T>(opts: AxiosRequestConfig, callback?: BodyResponseCallback<T>):
-      AxiosPromise|void;
+  request<T>(opts: GaxiosOptions, callback?: BodyResponseCallback<T>):
+      GaxiosPromise|void;
 }
 
 export interface BodyResponseCallback<T> {
   // The `body` object is a truly dynamic type.  It must be `any`.
-  (err: Error|null, res?: AxiosResponse<T>|null): void;
+  (err: Error|null, res?: GaxiosResponse<T>|null): void;
 }
 
-export interface RequestError extends AxiosError {
+export interface RequestError extends GaxiosError {
   errors: Error[];
 }
-
-/**
- * Axios will use XHR if it is available. In the case of Electron,
- * since XHR is there it will try to use that. This leads to OPTIONS
- * preflight requests which googleapis DOES NOT like. This line of
- * code pins the adapter to ensure it uses node.
- * https://github.com/google/google-api-nodejs-client/issues/1083
- */
-axios.defaults.adapter = require('axios/lib/adapters/http');
 
 export class DefaultTransporter {
   /**
@@ -60,10 +48,10 @@ export class DefaultTransporter {
 
   /**
    * Configures request options before making a request.
-   * @param opts AxiosRequestConfig options.
+   * @param opts GaxiosOptions options.
    * @return Configured options.
    */
-  configure(opts: AxiosRequestConfig = {}): AxiosRequestConfig {
+  configure(opts: GaxiosOptions = {}): GaxiosOptions {
     opts.headers = opts.headers || {};
     if (!isBrowser()) {
       // set transporter user agent if not in browser
@@ -79,16 +67,16 @@ export class DefaultTransporter {
   }
 
   /**
-   * Makes a request using Axios with given options.
-   * @param opts AxiosRequestConfig options.
-   * @param callback optional callback that contains AxiosResponse object.
-   * @return AxiosPromise, assuming no callback is passed.
+   * Makes a request using Gaxios with given options.
+   * @param opts GaxiosOptions options.
+   * @param callback optional callback that contains GaxiosResponse object.
+   * @return GaxiosPromise, assuming no callback is passed.
    */
-  request<T>(opts: AxiosRequestConfig): AxiosPromise<T>;
-  request<T>(opts: AxiosRequestConfig, callback?: BodyResponseCallback<T>):
+  request<T>(opts: GaxiosOptions): GaxiosPromise<T>;
+  request<T>(opts: GaxiosOptions, callback?: BodyResponseCallback<T>):
       void;
-  request<T>(opts: AxiosRequestConfig, callback?: BodyResponseCallback<T>):
-      AxiosPromise|void {
+  request<T>(opts: GaxiosOptions, callback?: BodyResponseCallback<T>):
+      GaxiosPromise|void {
     // ensure the user isn't passing in request-style options
     opts = this.configure(opts);
     try {
@@ -101,16 +89,8 @@ export class DefaultTransporter {
       }
     }
 
-    // If the user configured an `HTTPS_PROXY` environment variable, create
-    // a custom agent to proxy the request.
-    const proxy = process.env.HTTPS_PROXY || process.env.https_proxy;
-    if (proxy) {
-      opts.httpsAgent = new HttpsProxyAgent(proxy);
-      opts.proxy = false;
-    }
-
     if (callback) {
-      axios(opts).then(
+      request<T>(opts).then(
           r => {
             callback(null, r);
           },
@@ -118,7 +98,7 @@ export class DefaultTransporter {
             callback(this.processError(e));
           });
     } else {
-      return axios(opts).catch(e => {
+      return request<T>(opts).catch(e => {
         throw this.processError(e);
       });
     }
@@ -127,7 +107,7 @@ export class DefaultTransporter {
   /**
    * Changes the error to include details from the body.
    */
-  private processError(e: AxiosError): RequestError {
+  private processError(e: GaxiosError): RequestError {
     const res = e.response;
     const err = e as RequestError;
     const body = res ? res.data : null;

--- a/test/test.oauth2.ts
+++ b/test/test.oauth2.ts
@@ -15,9 +15,9 @@
  */
 
 import * as assert from 'assert';
-import {GaxiosError} from 'gaxios';
 import * as crypto from 'crypto';
 import * as fs from 'fs';
+import {GaxiosError} from 'gaxios';
 import * as nock from 'nock';
 import * as path from 'path';
 import * as qs from 'querystring';
@@ -27,6 +27,7 @@ import * as url from 'url';
 import {CodeChallengeMethod, OAuth2Client} from '../src';
 import {LoginTicket} from '../src/auth/loginticket';
 import * as messages from '../src/messages';
+
 const assertRejects = require('assert-rejects');
 
 nock.disableNetConnect();
@@ -642,9 +643,7 @@ it('should pass due to valid issuer', async () => {
 it('should be able to retrieve a list of Google certificates', (done) => {
   const scope = nock('https://www.googleapis.com')
                     .get(certsPath)
-                    .replyWithFile(200, certsResPath, {
-                      'Content-Type': 'application/json',
-                    });
+                    .replyWithFile(200, certsResPath);
   client.getFederatedSignonCerts((err, certs) => {
     assert.strictEqual(err, null);
     assert.strictEqual(Object.keys(certs!).length, 2);

--- a/test/test.oauth2.ts
+++ b/test/test.oauth2.ts
@@ -1002,8 +1002,8 @@ it('getToken should allow a code_verifier to be passed', async () => {
   scope.done();
   assert(res.res);
   if (!res.res) return;
-  const params = qs.parse(res.res.config.body);
-  assert.strictEqual(params.code_verifier, 'its_verified"');
+  const params = qs.parse(res.res.config.data);
+  assert.strictEqual(params.code_verifier, 'its_verified');
 });
 
 it('getToken should set redirect_uri if not provided in options', async () => {
@@ -1018,7 +1018,7 @@ it('getToken should set redirect_uri if not provided in options', async () => {
   scope.done();
   assert(res.res);
   if (!res.res) return;
-  const params = qs.parse(res.res.config.body);
+  const params = qs.parse(res.res.config.data);
   assert.strictEqual(params.redirect_uri, REDIRECT_URI);
 });
 
@@ -1034,7 +1034,7 @@ it('getToken should set client_id if not provided in options', async () => {
   scope.done();
   assert(res.res);
   if (!res.res) return;
-  const params = qs.parse(res.res.config.body);
+  const params = qs.parse(res.res.config.data);
   assert.strictEqual(params.client_id, CLIENT_ID);
 });
 
@@ -1051,7 +1051,7 @@ it('getToken should override redirect_uri if provided in options', async () => {
   scope.done();
   assert(res.res);
   if (!res.res) return;
-  const params = qs.parse(res.res.config.body);
+  const params = qs.parse(res.res.config.data);
   assert.strictEqual(params.redirect_uri, 'overridden');
 });
 
@@ -1068,7 +1068,7 @@ it('getToken should override client_id if provided in options', async () => {
   scope.done();
   assert(res.res);
   if (!res.res) return;
-  const params = qs.parse(res.res.config.body);
+  const params = qs.parse(res.res.config.data);
   assert.strictEqual(params.client_id, 'overridden');
 });
 

--- a/test/test.transporters.ts
+++ b/test/test.transporters.ts
@@ -99,8 +99,7 @@ it('should return an error if you try to use request config options with a promi
          `library is using Axios for requests. Please see https://github.com/axios/axios ` +
          `to learn more about the valid request options.`);
      const uri = 'http://example.com/api';
-     assert.throws(
-         () => transporter.request({uri} as GaxiosOptions), expected);
+     assert.throws(() => transporter.request({uri} as GaxiosOptions), expected);
    });
 
 it('should support invocation with async/await', async () => {

--- a/test/test.transporters.ts
+++ b/test/test.transporters.ts
@@ -15,7 +15,7 @@
  */
 
 import * as assert from 'assert';
-import {AxiosRequestConfig} from 'axios';
+import {GaxiosOptions} from 'gaxios';
 import * as nock from 'nock';
 
 import {DefaultTransporter, RequestError} from '../src/transporters';
@@ -30,16 +30,6 @@ nock.disableNetConnect();
 
 const defaultUserAgentRE = 'google-api-nodejs-client/\\d+.\\d+.\\d+';
 const transporter = new DefaultTransporter();
-
-it('should set default client user agent if none is set', async () => {
-  const url = 'http://example.com';
-  const scope = nock(url).get('/').reply(200, {});
-  const res = await transporter.request({url});
-  assert.strictEqual(typeof res.config.adapter, 'function');
-  assert.deepStrictEqual(
-      res.config.adapter, require('axios/lib/adapters/http'));
-  scope.done();
-});
 
 it('should set default adapter to node.js', () => {
   const opts = transporter.configure();
@@ -95,7 +85,7 @@ it('should return an error if you try to use request config options', done => {
   transporter.request(
       {
         uri: 'http://example.com/api',
-      } as AxiosRequestConfig,
+      } as GaxiosOptions,
       (error) => {
         assert.strictEqual(error!.message, expected);
         done();
@@ -110,7 +100,7 @@ it('should return an error if you try to use request config options with a promi
          `to learn more about the valid request options.`);
      const uri = 'http://example.com/api';
      assert.throws(
-         () => transporter.request({uri} as AxiosRequestConfig), expected);
+         () => transporter.request({uri} as GaxiosOptions), expected);
    });
 
 it('should support invocation with async/await', async () => {


### PR DESCRIPTION
This switches from Axios to Gaxios. Hopefully nobody notices.