### PR TITLE
fix: throw if there is no refresh token despite the necessity of refreshing

### DIFF
--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -642,7 +642,7 @@ export class OAuth2Client extends AuthClient {
   private async getAccessTokenAsync(): Promise<GetAccessTokenResponse> {
     const shouldRefresh =
         !this.credentials.access_token || this.isTokenExpiring();
-    if (shouldRefresh && this.credentials.refresh_token) {
+    if (shouldRefresh) {
       if (!this.credentials.refresh_token) {
         throw new Error('No refresh token is set.');
       }


### PR DESCRIPTION
If `OAuth2Client` without refresh token has no access token or has an expired access token, `OAuth2Client.prototype.getAccessToken` should throw an error.

This commit also reduces the number of unreachable code.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
