### PR TITLE
fix: avoid loading fast-text-encoding if not in browser environment

### DIFF
--- a/src/crypto/browser/crypto.ts
+++ b/src/crypto/browser/crypto.ts
@@ -19,11 +19,12 @@
 
 import * as base64js from 'base64-js';
 import {CryptoSigner} from '../crypto';
+import {isBrowser} from '../../isbrowser';
 
 // Not all browsers support `TextEncoder`. The following `require` will
 // provide a fast UTF8-only replacement for those browsers that don't support
 // text encoding natively.
-if (typeof TextEncoder === 'undefined') {
+if (isBrowser() && typeof TextEncoder === 'undefined') {
   require('fast-text-encoding');
 }
 


### PR DESCRIPTION
Fixes #626

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
