### PR TITLE
feat: support scopes on compute credentials

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "client library"
   ],
   "dependencies": {
+    "arrify": "^1.0.1",
     "base64-js": "^1.3.0",
     "fast-text-encoding": "^1.0.0",
     "gaxios": "^1.2.1",
@@ -29,6 +30,7 @@
   },
   "devDependencies": {
     "@compodoc/compodoc": "^1.1.7",
+    "@types/arrify": "^1.0.4",
     "@types/base64-js": "^1.2.5",
     "@types/chai": "^4.1.7",
     "@types/execa": "^0.9.0",

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -27,7 +27,7 @@ import {isBrowser} from '../isbrowser';
 import * as messages from '../messages';
 import {DefaultTransporter, Transporter} from '../transporters';
 
-import {Compute} from './computeclient';
+import {Compute, ComputeOptions} from './computeclient';
 import {CredentialBody, JWTInput} from './credentials';
 import {GCPEnv, getEnv} from './envDetect';
 import {JWT, JWTOptions} from './jwtclient';
@@ -219,7 +219,7 @@ export class GoogleAuth {
     }
   }
 
-  private async getApplicationDefaultAsync(options?: RefreshOptions):
+  private async getApplicationDefaultAsync(options: RefreshOptions = {}):
       Promise<ADCResponse> {
     // If we've already got a cached credential, just return it.
     if (this.cachedCredential) {
@@ -276,6 +276,7 @@ export class GoogleAuth {
 
     // For GCE, just return a default ComputeClient. It will take care of
     // the rest.
+    (options as ComputeOptions).scopes = this.scopes;
     this.cachedCredential = new Compute(options);
     projectId = await this.getProjectId();
     return {projectId, credential: this.cachedCredential};

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -29,6 +29,7 @@ const assertRejects = require('assert-rejects');
 import {GoogleAuth, JWT, UserRefreshClient} from '../src';
 import {CredentialBody} from '../src/auth/credentials';
 import * as envDetect from '../src/auth/envDetect';
+import {Compute} from '../src/auth/computeclient';
 import * as messages from '../src/messages';
 
 nock.disableNetConnect();
@@ -1134,6 +1135,14 @@ describe('googleauth', () => {
     const keyFilename = './test/fixtures/private.json';
     const client = await auth.getClient({scopes, keyFilename}) as JWT;
     assert.strictEqual(client.scopes, scopes);
+  });
+
+  it('should allow passing a scope to get a Compute client', async () => {
+    const scopes = ['http://examples.com/is/a/scope'];
+    const scope = nockIsGCE();
+    const client = await auth.getClient({scopes}) as Compute;
+    assert.strictEqual(client.scopes, scopes);
+    scope.done();
   });
 
   it('should get an access token', async () => {

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -1139,10 +1139,10 @@ describe('googleauth', () => {
 
   it('should allow passing a scope to get a Compute client', async () => {
     const scopes = ['http://examples.com/is/a/scope'];
-    const scope = nockIsGCE();
+    const nockScopes = [nockIsGCE(), createGetProjectIdNock()];
     const client = await auth.getClient({scopes}) as Compute;
     assert.strictEqual(client.scopes, scopes);
-    scope.done();
+    nockScopes.forEach(x => x.done());
   });
 
   it('should get an access token', async () => {


### PR DESCRIPTION
The GCE metadata server is adding support for requesting tokens against user accounts with a predefined set of scopes.  This adds experimental support for passing the scopes as querystring parameters to the metadata service in compute credentials.
