### PR TITLE
fix: getCredential(): load credentials with getClient()

### DIFF
--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -658,6 +658,8 @@ export class GoogleAuth {
   }
 
   private async getCredentialsAsync(): Promise<CredentialBody> {
+    await this.getClient();
+
     if (this.jsonContent) {
       const credential: CredentialBody = {
         client_email: this.jsonContent.client_email,

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -1199,8 +1199,10 @@ describe('googleauth', () => {
 
     const result =
         await auth._tryGetApplicationCredentialsFromEnvironmentVariable();
-    if (!(result instanceof JWT))
-      throw new assert.AssertionError({ message: 'Credentials are not a JWT object'});
+    if (!(result instanceof JWT)) {
+      throw new assert.AssertionError(
+          {message: 'Credentials are not a JWT object'});
+    }
 
     assert.notEqual(null, body);
     assert(spy.calledOnce);

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -1188,6 +1188,26 @@ describe('googleauth', () => {
     assert.strictEqual(jwt.key, body!.private_key);
   });
 
+  it('getCredentials should call getClient to load credentials', async () => {
+    // Set up a mock to return path to a valid credentials file.
+    blockGoogleApplicationCredentialEnvironmentVariable();
+    mockEnvVar(
+        'GOOGLE_APPLICATION_CREDENTIALS', './test/fixtures/private.json');
+
+    const spy = sinon.spy(auth, 'getClient');
+    const body = await auth.getCredentials();
+
+    const result =
+        await auth._tryGetApplicationCredentialsFromEnvironmentVariable();
+    if (!(result instanceof JWT))
+      throw new assert.AssertionError({ message: 'Credentials are not a JWT object'});
+
+    assert.notEqual(null, body);
+    assert(spy.calledOnce);
+    assert.strictEqual(result.email, body!.client_email);
+    assert.strictEqual(result.key, body!.private_key);
+  });
+
   it('getCredentials should handle valid file path', async () => {
     // Set up a mock to return path to a valid credentials file.
     blockGoogleApplicationCredentialEnvironmentVariable();


### PR DESCRIPTION
This change is needed for implementing v4 signed URL. The request that is to be signed needs  `client_email` before calling `GoogleAuth.sign()`, so we need to change it so that `getCredentials()` properly loads the credentials.