### PR TITLE
fix: surface original stack trace and message with errors

### DIFF
--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -70,7 +70,7 @@ export class Compute extends OAuth2Client {
     try {
       data = await gcpMetadata.instance(tokenPath);
     } catch (e) {
-      e.message = 'Could not refresh access token.';
+      e.message = `Could not refresh access token: ${e.message}`;
       throw e;
     }
     const tokens = data as Credentials;

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -258,8 +258,9 @@ export class GoogleAuth {
     try {
       isGCE = await this._checkIsGCE();
     } catch (e) {
-      throw new Error(
-          'Unexpected error determining execution environment: ' + e.message);
+      e.message =
+          `Unexpected error determining execution environment: ${e.message}`;
+      throw e;
     }
 
     if (!isGCE) {
@@ -303,9 +304,10 @@ export class GoogleAuth {
       return this._getApplicationCredentialsFromFilePath(
           credentialsPath, options);
     } catch (e) {
-      throw this.createError(
-          'Unable to read the credential file specified by the GOOGLE_APPLICATION_CREDENTIALS environment variable.',
-          e);
+      e.message =
+          `Unable to read the credential file specified by the GOOGLE_APPLICATION_CREDENTIALS environment variable: ${
+              e.message}`;
+      throw e;
     }
   }
 
@@ -375,17 +377,14 @@ export class GoogleAuth {
         throw new Error();
       }
     } catch (err) {
-      throw this.createError(
-          `The file at ${filePath} does not exist, or it is not a file.`, err);
+      err.message = `The file at ${
+          filePath} does not exist, or it is not a file. ${err.message}`;
+      throw err;
     }
 
     // Now open a read stream on the file, and parse it.
-    try {
-      const readStream = this._createReadStream(filePath);
-      return this.fromStream(readStream, options);
-    } catch (err) {
-      throw this.createError(`Unable to read the file at ${filePath}.`, err);
-    }
+    const readStream = this._createReadStream(filePath);
+    return this.fromStream(readStream, options);
   }
 
   /**
@@ -542,22 +541,6 @@ export class GoogleAuth {
    */
   _mockWellKnownFilePath(filePath: string) {
     return filePath;
-  }
-
-  // Creates an Error containing the given message, and includes the message
-  // from the optional err passed in.
-  private createError(message: string, err: Error) {
-    let s = message || '';
-    if (err) {
-      const errorMessage = String(err);
-      if (errorMessage && errorMessage.length > 0) {
-        if (s.length > 0) {
-          s += ' ';
-        }
-        s += errorMessage;
-      }
-    }
-    return Error(s);
   }
 
   /**

--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -718,7 +718,7 @@ export class OAuth2Client extends AuthClient {
       const e = err as GaxiosError;
       if (e.response &&
           (e.response.status === 403 || e.response.status === 404)) {
-        e.message = 'Could not refresh access token.';
+        e.message = `Could not refresh access token: ${e.message}`;
       }
       throw e;
     }
@@ -962,7 +962,8 @@ export class OAuth2Client extends AuthClient {
     try {
       res = await this.transporter.request({url});
     } catch (e) {
-      throw new Error('Failed to retrieve verification certificates: ' + e);
+      e.message = `Failed to retrieve verification certificates: ${e.message}`;
+      throw e;
     }
 
     const cacheControl = res ? res.headers['cache-control'] : undefined;
@@ -1037,7 +1038,9 @@ export class OAuth2Client extends AuthClient {
     try {
       envelope = JSON.parse(crypto.decodeBase64StringUtf8(segments[0]));
     } catch (err) {
-      throw new Error('Can\'t parse token envelope: ' + segments[0]);
+      err.message =
+          `Can't parse token envelope: ${segments[0]}': ${err.message}`;
+      throw err;
     }
 
     if (!envelope) {
@@ -1047,7 +1050,8 @@ export class OAuth2Client extends AuthClient {
     try {
       payload = JSON.parse(crypto.decodeBase64StringUtf8(segments[1]));
     } catch (err) {
-      throw new Error('Can\'t parse token payload: ' + segments[0]);
+      err.message = `Can't parse token payload '${segments[0]}`;
+      throw err;
     }
 
     if (!payload) {


### PR DESCRIPTION
Fixes #643.  This PR looks for multiple instances where context for exceptions could be lost.  The two primary types of cases here are:
1. Completely overwriting the error message but retaining the stack trace
2. Catching, and throwing an entirely new error with the original context lost

Instead, we always make sure to re-throw the original error, and consistently pin the original error message to the tail of the new message.  