### PR TITLE
fix: re-throw original exception and preserve message in compute client

### DIFF
--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -87,27 +87,20 @@ export class Compute extends OAuth2Client {
     return super.requestAsync<T>(opts, retry).catch(e => {
       const res = (e as GaxiosError).response;
       if (res && res.status) {
-        let helpfulMessage = null;
-        if (res.status === 403) {
-          helpfulMessage =
-              'A Forbidden error was returned while attempting to retrieve an access ' +
-              'token for the Compute Engine built-in service account. This may be because the Compute ' +
-              'Engine instance does not have the correct permission scopes specified.';
-        } else if (res.status === 404) {
-          helpfulMessage =
-              'A Not Found error was returned while attempting to retrieve an access' +
-              'token for the Compute Engine built-in service account. This may be because the Compute ' +
-              'Engine instance does not have any permission scopes specified.';
-        }
-        if (helpfulMessage) {
-          if (e && e.message && !retry) {
-            helpfulMessage += ' ' + e.message;
-          }
-          if (e) {
-            e.message = helpfulMessage;
-          } else {
-            e = new Error(helpfulMessage);
-            (e as NodeJS.ErrnoException).code = res.status.toString();
+        (e as NodeJS.ErrnoException).code = res.status.toString();
+        if (!retry) {
+          if (res.status === 403) {
+            e.message =
+                'A Forbidden error was returned while attempting to retrieve an access ' +
+                'token for the Compute Engine built-in service account. This may be because the Compute ' +
+                'Engine instance does not have the correct permission scopes specified: ' +
+                e.message;
+          } else if (res.status === 404) {
+            e.message =
+                'A Not Found error was returned while attempting to retrieve an access' +
+                'token for the Compute Engine built-in service account. This may be because the Compute ' +
+                'Engine instance does not have any permission scopes specified: ' +
+                e.message;
           }
         }
       }

--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -71,6 +71,7 @@ export class Compute extends OAuth2Client {
       data = await gcpMetadata.instance(tokenPath);
     } catch (e) {
       e.message = `Could not refresh access token: ${e.message}`;
+      this.wrapError(e);
       throw e;
     }
     const tokens = data as Credentials;
@@ -82,29 +83,23 @@ export class Compute extends OAuth2Client {
     return {tokens, res: null};
   }
 
-  protected requestAsync<T>(opts: GaxiosOptions, retry = false):
-      GaxiosPromise<T> {
-    return super.requestAsync<T>(opts, retry).catch(e => {
-      const res = (e as GaxiosError).response;
-      if (res && res.status) {
-        (e as NodeJS.ErrnoException).code = res.status.toString();
-        if (!retry) {
-          if (res.status === 403) {
-            e.message =
-                'A Forbidden error was returned while attempting to retrieve an access ' +
-                'token for the Compute Engine built-in service account. This may be because the Compute ' +
-                'Engine instance does not have the correct permission scopes specified: ' +
-                e.message;
-          } else if (res.status === 404) {
-            e.message =
-                'A Not Found error was returned while attempting to retrieve an access' +
-                'token for the Compute Engine built-in service account. This may be because the Compute ' +
-                'Engine instance does not have any permission scopes specified: ' +
-                e.message;
-          }
-        }
+  protected wrapError(e: GaxiosError) {
+    const res = e.response;
+    if (res && res.status) {
+      e.code = res.status.toString();
+      if (res.status === 403) {
+        e.message =
+            'A Forbidden error was returned while attempting to retrieve an access ' +
+            'token for the Compute Engine built-in service account. This may be because the Compute ' +
+            'Engine instance does not have the correct permission scopes specified: ' +
+            e.message;
+      } else if (res.status === 404) {
+        e.message =
+            'A Not Found error was returned while attempting to retrieve an access' +
+            'token for the Compute Engine built-in service account. This may be because the Compute ' +
+            'Engine instance does not have any permission scopes specified: ' +
+            e.message;
       }
-      throw e;
-    });
+    }
   }
 }

--- a/test/test.compute.ts
+++ b/test/test.compute.ts
@@ -37,11 +37,10 @@ function mockExample() {
 }
 
 // set up compute client.
-let sandbox: sinon.SinonSandbox;
+const sandbox = sinon.createSandbox();
 let compute: Compute;
 beforeEach(() => {
   compute = new Compute();
-  sandbox = sinon.createSandbox();
 });
 
 afterEach(() => {
@@ -129,37 +128,22 @@ it('should return false for createScopedRequired', () => {
 });
 
 it('should return a helpful message on request response.statusCode 403', async () => {
-  // Mock the credentials object. Make sure there's no expiry_date set.
-  compute.credentials = {refresh_token: 'hello', access_token: 'goodbye'};
-
-  const scopes = [
-    nock(url).get('/').reply(403), nock(HOST_ADDRESS).get(tokenPath).reply(403)
-  ];
-
+  const scope = mockToken(403);
   const expected = new RegExp(
       'A Forbidden error was returned while attempting to retrieve an access ' +
       'token for the Compute Engine built-in service account. This may be because the ' +
       'Compute Engine instance does not have the correct permission scopes specified. ' +
       'Could not refresh access token.');
-
   await assertRejects(compute.request({url}), expected);
-  scopes.forEach(s => s.done());
+  scope.done();
 });
 
 it('should return a helpful message on request response.statusCode 404', async () => {
-  // Mock the credentials object.
-  compute.credentials = {
-    refresh_token: 'hello',
-    access_token: 'goodbye',
-    expiry_date: (new Date(9999, 1, 1)).getTime()
-  };
-  // Mock the request method to return a 404.
-  const scope = nock(url).get('/').reply(404);
+  const scope = mockToken(404);
   const expected = new RegExp(
       'A Not Found error was returned while attempting to retrieve an access' +
       'token for the Compute Engine built-in service account. This may be because the ' +
       'Compute Engine instance does not have any permission scopes specified.');
-
   await assertRejects(compute.request({url}), expected);
   scope.done();
 });


### PR DESCRIPTION
Fixes #532.  The original error message returned from the GCE metadata service was getting swallowed.  This ensures the underlying exception is thrown, and the message is preserved.