### PR TITLE
docs: fix the CHANGELOG to reflect 3.x breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,8 +84,8 @@ The 2.0 version of this library used the [axios](https://github.com/axios/axios)
 #### BREAKING: `generateCodeVerifier` is now `generateCodeVerifierAsync`
 The `OAuth2Client.generateCodeVerifier` method has been replaced by the `OAuth2Client.generateCodeVerifierAsync` method.  It has changed from a synchronous method to an asynchronous method to support async browser crypto APIs required for Webpack support.
 
-#### BREAKING: `generateCodeVerifier` is now `generateCodeVerifierAsync`
-The `OAuth2Client.verifySignedJwtWithCerts` method has been replaced by the `OAuth2Client.verifySignedJwtWithCerts` method.  It has changed from a synchronous method to an asynchronous method to support async browser crypto APIs required for Webpack support.
+#### BREAKING: `verifySignedJwtWithCerts` is now `verifySignedJwtWithCertsAsync`
+The `OAuth2Client.verifySignedJwtWithCerts` method has been replaced by the `OAuth2Client.verifySignedJwtWithCertsAsync` method. It has changed from a synchronous method to an asynchronous method to support async browser crypto APIs required for Webpack support.
 
 
 ### New Features


### PR DESCRIPTION
Fixes #613.  There were errors in the changelog in the 3.0 release.  I already cleaned up the release notes in the GitHub release.