### PR TITLE
fix: un-deprecate `refreshAccessToken` method

### DIFF
--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -595,14 +595,12 @@ export class OAuth2Client extends AuthClient {
   /**
    * Retrieves the access token using refresh token
    *
-   * @deprecated use getRequestHeaders instead.
    * @param callback callback
    */
   refreshAccessToken(): Promise<RefreshAccessTokenResponse>;
   refreshAccessToken(callback: RefreshAccessTokenCallback): void;
   refreshAccessToken(callback?: RefreshAccessTokenCallback):
       Promise<RefreshAccessTokenResponse>|void {
-    messages.warn(messages.REFRESH_ACCESS_TOKEN_DEPRECATED);
     if (callback) {
       this.refreshAccessTokenAsync().then(
           r => callback(null, r.credentials, r.res), callback);

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -109,15 +109,6 @@ export const JWT_ACCESS_CREATE_SCOPED_DEPRECATED = {
   ].join(' ')
 };
 
-export const REFRESH_ACCESS_TOKEN_DEPRECATED = {
-  code: 'google-auth-library:DEP007',
-  type: WarningTypes.DEPRECATION,
-  message: [
-    'The `refreshAccessToken` method has been deprecated, and will be removed',
-    'in the 3.0 release of google-auth-library. Please use the `getRequestHeaders`',
-    'method instead.'
-  ].join(' ')
-};
 export const OAUTH_GET_REQUEST_METADATA_DEPRECATED = {
   code: 'google-auth-library:DEP004',
   type: WarningTypes.DEPRECATION,

--- a/test/test.oauth2.ts
+++ b/test/test.oauth2.ts
@@ -727,14 +727,6 @@ it('should return error in callback on request', done => {
   });
 });
 
-it('should emit warning on refreshAccessToken', async () => {
-  let warned = false;
-  sandbox.stub(process, 'emitWarning').callsFake(() => warned = true);
-  client.refreshAccessToken((err, result) => {
-    assert.strictEqual(warned, true);
-  });
-});
-
 it('should return error in callback on refreshAccessToken', done => {
   client.refreshAccessToken((err, result) => {
     assert.strictEqual(err!.message, 'No refresh token is set.');


### PR DESCRIPTION
Fixes #575.  In 3.0 we deprecated the `refreshAccessToken` method, thinking that it never made sense for users to call this method manually.  It's called automatically (if needed) as part of the `getRequestHeaders` method which is generall used to obtain tokens.  The user in https://github.com/googleapis/google-auth-library-nodejs/issues/575 makes a good case for a few scenarios where this makes sense:
- There are cases where you want to explicitly ask for a new token