### PR TITLE
feat: use X-Goog-Api-Key header

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/mocha": "^5.2.1",
     "@types/mv": "^2.1.0",
     "@types/ncp": "^2.0.1",
-    "@types/nock": "^10.0.0",
+    "@types/nock": "^10.0.3",
     "@types/node": "^10.5.1",
     "@types/semver": "^6.0.0",
     "@types/sinon": "^7.0.0",

--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -756,7 +756,7 @@ export class OAuth2Client extends AuthClient {
     }
 
     if (this.apiKey) {
-      return {headers: {}};
+      return {headers: {'X-Goog-Api-Key': this.apiKey}};
     }
     let r: GetTokenResponse | null = null;
     let tokens: Credentials | null = null;

--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -885,9 +885,9 @@ export class OAuth2Client extends AuthClient {
         opts.headers = opts.headers || {};
         opts.headers.Authorization = r.headers.Authorization;
       }
-
       if (this.apiKey) {
-        opts.params = Object.assign(opts.params || {}, {key: this.apiKey});
+        opts.headers = opts.headers || {};
+        opts.headers['X-Goog-Api-Key'] = this.apiKey;
       }
       r2 = await this.transporter.request<T>(opts);
     } catch (e) {

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -257,6 +257,12 @@ describe('googleauth', () => {
     scope.done();
   });
 
+  it('should put the api key in the headers', async () => {
+    const client = auth.fromAPIKey(API_KEY);
+    const headers = await client.getRequestHeaders();
+    assert.strictEqual(headers['X-Goog-Api-Key'], API_KEY);
+  });
+
   it('should make a request while preserving original parameters', async () => {
     const OTHER_QS_PARAM = {test: 'abc'};
     const scope = nock(BASE_URL)

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -242,9 +242,8 @@ describe('googleauth', () => {
   it('should make a request with the api key', async () => {
     const scope = nock(BASE_URL)
       .post(ENDPOINT)
-      .query({key: API_KEY})
-      .reply(uri => {
-        assert(uri.indexOf('key=' + API_KEY) > -1);
+      .reply(function(uri) {
+        assert.strictEqual(this.req.headers['x-goog-api-key'][0], API_KEY);
         return [200, RESPONSE_BODY];
       });
     const client = auth.fromAPIKey(API_KEY);
@@ -267,9 +266,9 @@ describe('googleauth', () => {
     const OTHER_QS_PARAM = {test: 'abc'};
     const scope = nock(BASE_URL)
       .post(ENDPOINT)
-      .query({test: OTHER_QS_PARAM.test, key: API_KEY})
-      .reply(uri => {
-        assert(uri.indexOf('key=' + API_KEY) > -1);
+      .query({test: OTHER_QS_PARAM.test})
+      .reply(function(uri) {
+        assert.strictEqual(this.req.headers['x-goog-api-key'][0], API_KEY);
         assert(uri.indexOf('test=' + OTHER_QS_PARAM.test) > -1);
         return [200, RESPONSE_BODY];
       });


### PR DESCRIPTION
We have this thing called gRPC Fallback, which supports API keys and requires them to be sent in this special header `X-Goog-Api-Key`.  Some details [here](https://cloud.google.com/apis/docs/system-parameters) and more details - with JavaScript code sample I wrote - [here](https://googleapis.github.io/HowToRPC.html).

Let's set this header so that the [JavaScript code](https://github.com/googleapis/googleapis.github.io/blob/5d7c512d44e80f1abecd4e0bafb9ed7eb40168a3/examples/rpc/javascript/src/index.js#L49) could use `getRequestHeaders` in both service account and API key use cases.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
