### PR TITLE
fix(compute): correctly specify scopes when fetching token

### DIFF
--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -80,13 +80,16 @@ export class Compute extends OAuth2Client {
     const tokenPath = `service-accounts/${this.serviceAccountEmail}/token`;
     let data: CredentialRequest;
     try {
-      data = await gcpMetadata.instance({
+      const instanceOptions: gcpMetadata.Options = {
         property: tokenPath,
-        params: {
+      };
+      if (this.scopes.length > 0) {
+        instanceOptions.params = {
           scopes: this.scopes.join(','),
-          // TODO: clean up before submit, fix upstream type bug
-        } as {},
-      });
+        };
+        // TODO: clean up before submit, fix upstream type bug
+      };
+      data = await gcpMetadata.instance(instanceOptions);
     } catch (e) {
       e.message = `Could not refresh access token: ${e.message}`;
       this.wrapError(e);

--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -88,7 +88,7 @@ export class Compute extends OAuth2Client {
           scopes: this.scopes.join(','),
         };
         // TODO: clean up before submit, fix upstream type bug
-      };
+      }
       data = await gcpMetadata.instance(instanceOptions);
     } catch (e) {
       e.message = `Could not refresh access token: ${e.message}`;

--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -83,7 +83,7 @@ export class Compute extends OAuth2Client {
       data = await gcpMetadata.instance({
         property: tokenPath,
         params: {
-          scopes: this.scopes,
+          scopes: this.scopes.join(','),
           // TODO: clean up before submit, fix upstream type bug
         } as {},
       });

--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -87,7 +87,6 @@ export class Compute extends OAuth2Client {
         instanceOptions.params = {
           scopes: this.scopes.join(','),
         };
-        // TODO: clean up before submit, fix upstream type bug
       }
       data = await gcpMetadata.instance(instanceOptions);
     } catch (e) {

--- a/test/test.compute.ts
+++ b/test/test.compute.ts
@@ -29,7 +29,7 @@ const tokenPath = `${BASE_PATH}/instance/service-accounts/default/token`;
 function mockToken(statusCode = 200, scopes?: string[]) {
   let path = tokenPath;
   if (scopes && scopes.length > 0) {
-    path += '?' + qs.stringify({scopes});
+    path += `?scopes=${encodeURIComponent(scopes.join(','))}`;
   }
   return nock(HOST_ADDRESS)
     .get(path, undefined, {reqheaders: HEADERS})

--- a/test/test.compute.ts
+++ b/test/test.compute.ts
@@ -68,15 +68,25 @@ it('should get an access token for the first request', async () => {
   assert.strictEqual(compute.credentials.access_token, 'abc123');
 });
 
-it('should include scopes when asking for the token', async () => {
+it('should URI-encode and comma-separate scopes when fetching the token', async () => {
   const scopes = [
     'https://www.googleapis.com/reader',
     'https://www.googleapis.com/auth/plus',
   ];
-  const nockScopes = [mockToken(200, scopes), mockExample()];
+
+  const path = `${tokenPath}?scopes=${encodeURIComponent(scopes.join(','))}`;
+
+  const tokenFetchNock = nock(HOST_ADDRESS)
+    .get(path, undefined, {reqheaders: HEADERS})
+    .reply(200, {access_token: 'abc123', expires_in: 10000}, HEADERS);
+  const apiRequestNock = mockExample();
+
   const compute = new Compute({scopes});
   await compute.request({url});
-  nockScopes.forEach(s => s.done());
+
+  tokenFetchNock.done();
+  apiRequestNock.done();
+
   assert.strictEqual(compute.credentials.access_token, 'abc123');
 });
 


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-storage/issues/748

According to the requirements of the metadata server, this array of values was being parsed incorrectly by gaxios, which uses `querystring.stringify()`. The scopes query string parameter is expected as a comma-separated string value, as opposed to the `?scope=scope1&scopes=scope2` style that `querystring.stringify()` uses: https://cloud.google.com/functions/docs/securing/function-identity#access_tokens