### PR TITLE
fix!: remove deprecated methods

### DIFF
--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -57,20 +57,6 @@ export class Compute extends OAuth2Client {
   }
 
   /**
-   * Indicates whether the credential requires scopes to be created by calling
-   * createdScoped before use.
-   * @deprecated
-   * @return Boolean indicating if scope is required.
-   */
-  createScopedRequired() {
-    // On compute engine, scopes are specified at the compute instance's
-    // creation time, and cannot be changed. For this reason, always return
-    // false.
-    messages.warn(messages.COMPUTE_CREATE_SCOPED_DEPRECATED);
-    return false;
-  }
-
-  /**
    * Refreshes the access token.
    * @param refreshToken Unused parameter
    */

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -137,23 +137,6 @@ export class GoogleAuth {
   }
 
   /**
-   * THIS METHOD HAS BEEN DEPRECATED.
-   * It will be removed in 3.0.  Please use getProjectId instead.
-   */
-  getDefaultProjectId(): Promise<string>;
-  getDefaultProjectId(callback: ProjectIdCallback): void;
-  getDefaultProjectId(
-    callback?: ProjectIdCallback
-  ): Promise<string | null> | void {
-    messages.warn(messages.DEFAULT_PROJECT_ID_DEPRECATED);
-    if (callback) {
-      this.getProjectIdAsync().then(r => callback(null, r), callback);
-    } else {
-      return this.getProjectIdAsync();
-    }
-  }
-
-  /**
    * Obtains the default project ID for the application.
    * @param callback Optional callback
    * @returns Promise that resolves with project Id (if used without callback)

--- a/src/auth/iam.ts
+++ b/src/auth/iam.ts
@@ -35,33 +35,6 @@ export class IAMAuth {
   }
 
   /**
-   * Indicates whether the credential requires scopes to be created by calling
-   * createdScoped before use.
-   * @deprecated
-   * @return always false
-   */
-  createScopedRequired() {
-    // IAM authorization does not use scopes.
-    messages.warn(messages.IAM_CREATE_SCOPED_DEPRECATED);
-    return false;
-  }
-
-  /**
-   * Pass the selector and token to the metadataFn callback.
-   * @deprecated
-   * @param unused_uri is required of the credentials interface
-   * @param metadataFn a callback invoked with object containing request
-   * metadata.
-   */
-  getRequestMetadata(
-    unusedUri: string | null,
-    metadataFn: (err: Error | null, metadata?: RequestMetadata) => void
-  ) {
-    messages.warn(messages.IAM_GET_REQUEST_METADATA_DEPRECATED);
-    metadataFn(null, this.getRequestHeaders());
-  }
-
-  /**
    * Acquire the HTTP headers required to make an authenticated request.
    */
   getRequestHeaders() {

--- a/src/auth/jwtaccess.ts
+++ b/src/auth/jwtaccess.ts
@@ -60,35 +60,6 @@ export class JWTAccess {
   }
 
   /**
-   * Indicates whether the credential requires scopes to be created by calling
-   * createdScoped before use.
-   * @deprecated
-   * @return always false
-   */
-  createScopedRequired(): boolean {
-    // JWT Header authentication does not use scopes.
-    messages.warn(messages.JWT_ACCESS_CREATE_SCOPED_DEPRECATED);
-    return false;
-  }
-
-  /**
-   * Get a non-expired access token, after refreshing if necessary.
-   *
-   * @param authURI The URI being authorized.
-   * @param additionalClaims An object with a set of additional claims to
-   * include in the payload.
-   * @deprecated Please use `getRequestHeaders` instead.
-   * @returns An object that includes the authorization header.
-   */
-  getRequestMetadata(
-    url: string,
-    additionalClaims?: Claims
-  ): RequestMetadataResponse {
-    messages.warn(messages.JWT_ACCESS_GET_REQUEST_METADATA_DEPRECATED);
-    return {headers: this.getRequestHeaders(url, additionalClaims)};
-  }
-
-  /**
    * Get a non-expired access token, after refreshing if necessary.
    *
    * @param url The URI being authorized.

--- a/src/auth/jwtclient.ts
+++ b/src/auth/jwtclient.ts
@@ -146,17 +146,6 @@ export class JWT extends OAuth2Client {
   }
 
   /**
-   * Indicates whether the credential requires scopes to be created by calling
-   * createScoped before use.
-   * @deprecated
-   * @return false if createScoped does not need to be called.
-   */
-  createScopedRequired() {
-    messages.warn(messages.JWT_CREATE_SCOPED_DEPRECATED);
-    return !this.hasScopes();
-  }
-
-  /**
    * Determine if there are currently scopes available.
    */
   private hasScopes() {

--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -629,28 +629,6 @@ export class OAuth2Client extends AuthClient {
     return {tokens, res};
   }
 
-  /**
-   * Retrieves the access token using refresh token
-   *
-   * @deprecated use getRequestHeaders instead.
-   * @param callback callback
-   */
-  refreshAccessToken(): Promise<RefreshAccessTokenResponse>;
-  refreshAccessToken(callback: RefreshAccessTokenCallback): void;
-  refreshAccessToken(
-    callback?: RefreshAccessTokenCallback
-  ): Promise<RefreshAccessTokenResponse> | void {
-    messages.warn(messages.REFRESH_ACCESS_TOKEN_DEPRECATED);
-    if (callback) {
-      this.refreshAccessTokenAsync().then(
-        r => callback(null, r.credentials, r.res),
-        callback
-      );
-    } else {
-      return this.refreshAccessTokenAsync();
-    }
-  }
-
   private async refreshAccessTokenAsync() {
     const r = await this.refreshToken(this.credentials.refresh_token);
     const tokens = r.tokens as Credentials;
@@ -694,33 +672,6 @@ export class OAuth2Client extends AuthClient {
       return {token: r.credentials.access_token, res: r.res};
     } else {
       return {token: this.credentials.access_token};
-    }
-  }
-
-  /**
-   * Obtain the set of headers required to authenticate a request.
-   *
-   * @deprecated Use getRequestHeaders instead.
-   * @param url the Uri being authorized
-   * @param callback the func described above
-   */
-  getRequestMetadata(url?: string | null): Promise<RequestMetadataResponse>;
-  getRequestMetadata(
-    url: string | null,
-    callback: RequestMetadataCallback
-  ): void;
-  getRequestMetadata(
-    url: string | null,
-    callback?: RequestMetadataCallback
-  ): Promise<RequestMetadataResponse> | void {
-    messages.warn(messages.OAUTH_GET_REQUEST_METADATA_DEPRECATED);
-    if (callback) {
-      this.getRequestMetadataAsync(url).then(
-        r => callback(null, r.headers, r.res),
-        callback
-      );
-    } else {
-      return this.getRequestMetadataAsync();
     }
   }
 

--- a/test/test.compute.ts
+++ b/test/test.compute.ts
@@ -140,19 +140,6 @@ it('should not refresh if access token has not expired', async () => {
   scope.done();
 });
 
-it('should emit warning for createScopedRequired', () => {
-  let called = false;
-  sandbox.stub(process, 'emitWarning').callsFake(() => (called = true));
-  // tslint:disable-next-line deprecation
-  compute.createScopedRequired();
-  assert.strictEqual(called, true);
-});
-
-it('should return false for createScopedRequired', () => {
-  // tslint:disable-next-line deprecation
-  assert.strictEqual(false, compute.createScopedRequired());
-});
-
 it('should return a helpful message on request response.statusCode 403', async () => {
   const scope = mockToken(403);
   const expected = new RegExp(

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -1291,56 +1291,6 @@ describe('googleauth', () => {
     assert.strictEqual(value, signature);
   });
 
-  // tslint:disable-next-line ban
-  it.skip('should warn the user if using default Cloud SDK credentials', done => {
-    exposeLinuxWellKnownFile = true;
-    createLinuxWellKnownStream = () =>
-      fs.createReadStream('./test/fixtures/wellKnown.json');
-    sandbox.stub(process, 'emitWarning').callsFake((message, warningOrType) => {
-      assert.strictEqual(
-        message,
-        messages.PROBLEMATIC_CREDENTIALS_WARNING.message
-      );
-      const warningType =
-        typeof warningOrType === 'string'
-          ? warningOrType
-          : // @types/node doesn't recognize the emitWarning syntax which
-            // tslint:disable-next-line no-any
-            (warningOrType as any).type;
-      assert.strictEqual(warningType, messages.WarningTypes.WARNING);
-      done();
-    });
-    auth._tryGetApplicationCredentialsFromWellKnownFile();
-  });
-
-  it('should warn the user if using the getDefaultProjectId method', done => {
-    mockEnvVar('GCLOUD_PROJECT', STUB_PROJECT);
-    sandbox.stub(process, 'emitWarning').callsFake((message, warningOrType) => {
-      assert.strictEqual(
-        message,
-        messages.DEFAULT_PROJECT_ID_DEPRECATED.message
-      );
-      const warningType =
-        typeof warningOrType === 'string'
-          ? warningOrType
-          : // @types/node doesn't recognize the emitWarning syntax which
-            // tslint:disable-next-line no-any
-            (warningOrType as any).type;
-      assert.strictEqual(warningType, messages.WarningTypes.DEPRECATION);
-      done();
-    });
-    auth.getDefaultProjectId();
-  });
-
-  it('should only emit warnings once', async () => {
-    // The warning was used above, so invoking it here should have no effect.
-    mockEnvVar('GCLOUD_PROJECT', STUB_PROJECT);
-    let count = 0;
-    sandbox.stub(process, 'emitWarning').callsFake(() => count++);
-    await auth.getDefaultProjectId();
-    assert.strictEqual(count, 0);
-  });
-
   it('should pass options to the JWT constructor via getClient', async () => {
     const subject = 'science!';
     const auth = new GoogleAuth({keyFilename: './test/fixtures/private.json'});

--- a/test/test.iam.ts
+++ b/test/test.iam.ts
@@ -18,40 +18,25 @@ import * as assert from 'assert';
 import * as sinon from 'sinon';
 
 import {IAMAuth} from '../src';
-import * as messages from '../src/messages';
 
 const testSelector = 'a-test-selector';
 const testToken = 'a-test-token';
 
-let sandbox: sinon.SinonSandbox;
-let client: IAMAuth;
-beforeEach(() => {
-  sandbox = sinon.createSandbox();
-  client = new IAMAuth(testSelector, testToken);
-});
-afterEach(() => {
-  sandbox.restore();
-});
-
-it('passes the token and selector to the callback ', async () => {
-  const creds = client.getRequestHeaders();
-  assert.notStrictEqual(creds, null, 'metadata should be present');
-  assert.strictEqual(creds!['x-goog-iam-authority-selector'], testSelector);
-  assert.strictEqual(creds!['x-goog-iam-authorization-token'], testToken);
-});
-
-it('should warn about deprecation of getRequestMetadata', done => {
-  const stub = sandbox.stub(messages, 'warn');
-  // tslint:disable-next-line deprecation
-  client.getRequestMetadata(null, () => {
-    assert.strictEqual(stub.calledOnce, true);
-    done();
+describe(__filename, () => {
+  let sandbox: sinon.SinonSandbox;
+  let client: IAMAuth;
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    client = new IAMAuth(testSelector, testToken);
   });
-});
+  afterEach(() => {
+    sandbox.restore();
+  });
 
-it('should emit warning for createScopedRequired', () => {
-  const stub = sandbox.stub(process, 'emitWarning');
-  // tslint:disable-next-line deprecation
-  client.createScopedRequired();
-  assert(stub.called);
+  it('passes the token and selector to the callback ', async () => {
+    const creds = client.getRequestHeaders();
+    assert.notStrictEqual(creds, null, 'metadata should be present');
+    assert.strictEqual(creds!['x-goog-iam-authority-selector'], testSelector);
+    assert.strictEqual(creds!['x-goog-iam-authorization-token'], testToken);
+  });
 });

--- a/test/test.jwt.ts
+++ b/test/test.jwt.ts
@@ -71,14 +71,6 @@ afterEach(() => {
   sandbox.restore();
 });
 
-it('should emit warning for createScopedRequired', () => {
-  let called = false;
-  sandbox.stub(process, 'emitWarning').callsFake(() => (called = true));
-  // tslint:disable-next-line deprecation
-  jwt.createScopedRequired();
-  assert.strictEqual(called, true);
-});
-
 it('should create a dummy refresh token string', () => {
   // It is important that the compute client is created with a refresh token
   // value filled in, or else the rest of the logic will not work.
@@ -585,72 +577,6 @@ it('createScoped should not return the original instance', () => {
   });
   const clone = jwt.createScoped('hi');
   assert.notStrictEqual(jwt, clone);
-});
-
-it('createScopedRequired should return true when scopes is null', () => {
-  const jwt = new JWT({
-    email: 'foo@serviceaccount.com',
-    keyFile: '/path/to/key.pem',
-    subject: 'bar@subjectaccount.com',
-  });
-  // tslint:disable-next-line deprecation
-  assert.strictEqual(true, jwt.createScopedRequired());
-});
-
-it('createScopedRequired should return true when scopes is an empty array', () => {
-  const jwt = new JWT({
-    email: 'foo@serviceaccount.com',
-    keyFile: '/path/to/key.pem',
-    scopes: [],
-    subject: 'bar@subjectaccount.com',
-  });
-  // tslint:disable-next-line deprecation
-  assert.strictEqual(true, jwt.createScopedRequired());
-});
-
-it('createScopedRequired should return true when scopes is an empty string', () => {
-  const jwt = new JWT({
-    email: 'foo@serviceaccount.com',
-    keyFile: '/path/to/key.pem',
-    scopes: '',
-    subject: 'bar@subjectaccount.com',
-  });
-  // tslint:disable-next-line deprecation
-  assert.strictEqual(true, jwt.createScopedRequired());
-});
-
-it('createScopedRequired should return false when scopes is a filled-in string', () => {
-  const jwt = new JWT({
-    email: 'foo@serviceaccount.com',
-    keyFile: '/path/to/key.pem',
-    scopes: 'http://foo',
-    subject: 'bar@subjectaccount.com',
-  });
-  // tslint:disable-next-line deprecation
-  assert.strictEqual(false, jwt.createScopedRequired());
-});
-
-it('createScopedRequired should return false when scopes is a filled-in array', () => {
-  const jwt = new JWT({
-    email: 'foo@serviceaccount.com',
-    keyFile: '/path/to/key.pem',
-    scopes: ['http://bar', 'http://foo'],
-    subject: 'bar@subjectaccount.com',
-  });
-
-  // tslint:disable-next-line deprecation
-  assert.strictEqual(false, jwt.createScopedRequired());
-});
-
-it('createScopedRequired should return false when scopes is not an array or a string, but can be used as a string', () => {
-  const jwt = new JWT({
-    email: 'foo@serviceaccount.com',
-    keyFile: '/path/to/key.pem',
-    scopes: '2',
-    subject: 'bar@subjectaccount.com',
-  });
-  // tslint:disable-next-line deprecation
-  assert.strictEqual(false, jwt.createScopedRequired());
 });
 
 it('fromJson should error on null json', () => {

--- a/test/test.jwtaccess.ts
+++ b/test/test.jwtaccess.ts
@@ -20,171 +20,154 @@ import * as jws from 'jws';
 import * as sinon from 'sinon';
 
 import {JWTAccess} from '../src';
-import * as messages from '../src/messages';
 
-const keypair = require('keypair');
+describe(__filename, () => {
+  const keypair = require('keypair');
 
-// Creates a standard JSON credentials object for testing.
-const json = {
-  private_key_id: 'key123',
-  private_key: 'privatekey',
-  client_email: 'hello@youarecool.com',
-  client_id: 'client123',
-  type: 'service_account',
-};
+  // Creates a standard JSON credentials object for testing.
+  const json = {
+    private_key_id: 'key123',
+    private_key: 'privatekey',
+    client_email: 'hello@youarecool.com',
+    client_id: 'client123',
+    type: 'service_account',
+  };
 
-const keys = keypair(1024 /* bitsize of private key */);
-const testUri = 'http:/example.com/my_test_service';
-const email = 'foo@serviceaccount.com';
+  const keys = keypair(1024 /* bitsize of private key */);
+  const testUri = 'http:/example.com/my_test_service';
+  const email = 'foo@serviceaccount.com';
 
-let client: JWTAccess;
-let sandbox: sinon.SinonSandbox;
-beforeEach(() => {
-  client = new JWTAccess();
-  sandbox = sinon.createSandbox();
-});
-afterEach(() => {
-  sandbox.restore();
-});
+  let client: JWTAccess;
+  let sandbox: sinon.SinonSandbox;
+  beforeEach(() => {
+    client = new JWTAccess();
+    sandbox = sinon.createSandbox();
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
 
-it('should emit warning for createScopedRequired', () => {
-  const stub = sandbox.stub(process, 'emitWarning');
-  // tslint:disable-next-line deprecation
-  client.createScopedRequired();
-  assert(stub.called);
-});
+  it('getRequestHeaders should create a signed JWT token as the access token', () => {
+    const client = new JWTAccess(email, keys.private);
+    const headers = client.getRequestHeaders(testUri);
+    assert.notStrictEqual(null, headers, 'an creds object should be present');
+    const decoded = jws.decode(headers.Authorization.replace('Bearer ', ''));
+    assert.deepStrictEqual({alg: 'RS256', typ: 'JWT'}, decoded.header);
+    const payload = decoded.payload;
+    assert.strictEqual(email, payload.iss);
+    assert.strictEqual(email, payload.sub);
+    assert.strictEqual(testUri, payload.aud);
+  });
 
-it('getRequestHeaders should create a signed JWT token as the access token', () => {
-  const client = new JWTAccess(email, keys.private);
-  const headers = client.getRequestHeaders(testUri);
-  assert.notStrictEqual(null, headers, 'an creds object should be present');
-  const decoded = jws.decode(headers.Authorization.replace('Bearer ', ''));
-  assert.deepStrictEqual({alg: 'RS256', typ: 'JWT'}, decoded.header);
-  const payload = decoded.payload;
-  assert.strictEqual(email, payload.iss);
-  assert.strictEqual(email, payload.sub);
-  assert.strictEqual(testUri, payload.aud);
-});
+  it('getRequestHeaders should set key id in header when available', () => {
+    const client = new JWTAccess(email, keys.private, '101');
+    const headers = client.getRequestHeaders(testUri);
+    const decoded = jws.decode(headers.Authorization.replace('Bearer ', ''));
+    assert.deepStrictEqual(
+      {alg: 'RS256', typ: 'JWT', kid: '101'},
+      decoded.header
+    );
+  });
 
-it('getRequestHeaders should set key id in header when available', () => {
-  const client = new JWTAccess(email, keys.private, '101');
-  const headers = client.getRequestHeaders(testUri);
-  const decoded = jws.decode(headers.Authorization.replace('Bearer ', ''));
-  assert.deepStrictEqual(
-    {alg: 'RS256', typ: 'JWT', kid: '101'},
-    decoded.header
-  );
-});
+  it('getRequestHeaders should not allow overriding with additionalClaims', () => {
+    const client = new JWTAccess(email, keys.private);
+    const additionalClaims = {iss: 'not-the-email'};
+    assert.throws(() => {
+      client.getRequestHeaders(testUri, additionalClaims);
+    }, /^Error: The 'iss' property is not allowed when passing additionalClaims. This claim is included in the JWT by default.$/);
+  });
 
-it('getRequestHeaders should not allow overriding with additionalClaims', () => {
-  const client = new JWTAccess(email, keys.private);
-  const additionalClaims = {iss: 'not-the-email'};
-  assert.throws(() => {
-    client.getRequestHeaders(testUri, additionalClaims);
-  }, /^Error: The 'iss' property is not allowed when passing additionalClaims. This claim is included in the JWT by default.$/);
-});
-
-it('getRequestHeaders should return a cached token on the second request', () => {
-  const client = new JWTAccess(email, keys.private);
-  const res = client.getRequestHeaders(testUri);
-  const res2 = client.getRequestHeaders(testUri);
-  assert.strictEqual(res, res2);
-});
-
-it('getRequestHeaders should not return cached tokens older than an hour', () => {
-  const client = new JWTAccess(email, keys.private);
-  const res = client.getRequestHeaders(testUri);
-  const realDateNow = Date.now;
-  try {
-    // go forward in time one hour (plus a little)
-    Date.now = () => realDateNow() + 1000 * 60 * 60 + 10;
+  it('getRequestHeaders should return a cached token on the second request', () => {
+    const client = new JWTAccess(email, keys.private);
+    const res = client.getRequestHeaders(testUri);
     const res2 = client.getRequestHeaders(testUri);
-    assert.notStrictEqual(res, res2);
-  } finally {
-    // return date.now to it's normally scheduled programming
-    Date.now = realDateNow;
-  }
-});
+    assert.strictEqual(res, res2);
+  });
 
-it('createScopedRequired should return false', () => {
-  const client = new JWTAccess('foo@serviceaccount.com', null);
-  // tslint:disable-next-line deprecation
-  assert.strictEqual(false, client.createScopedRequired());
-});
+  it('getRequestHeaders should not return cached tokens older than an hour', () => {
+    const client = new JWTAccess(email, keys.private);
+    const res = client.getRequestHeaders(testUri);
+    const realDateNow = Date.now;
+    try {
+      // go forward in time one hour (plus a little)
+      Date.now = () => realDateNow() + 1000 * 60 * 60 + 10;
+      const res2 = client.getRequestHeaders(testUri);
+      assert.notStrictEqual(res, res2);
+    } finally {
+      // return date.now to it's normally scheduled programming
+      Date.now = realDateNow;
+    }
+  });
 
-it('fromJson should error on null json', () => {
-  assert.throws(() => {
+  it('fromJson should error on null json', () => {
+    assert.throws(() => {
+      // Test verifies invalid parameter tests, which requires cast to any.
+      // tslint:disable-next-line no-any
+      (client as any).fromJSON(null);
+    });
+  });
+
+  it('fromJson should error on empty json', () => {
+    assert.throws(() => {
+      client.fromJSON({});
+    });
+  });
+
+  it('fromJson should error on missing client_email', () => {
+    const j = Object.assign({}, json);
+    delete j.client_email;
+    assert.throws(() => {
+      client.fromJSON(j);
+    });
+  });
+
+  it('fromJson should error on missing private_key', () => {
+    const j = Object.assign({}, json);
+    delete j.private_key;
+    assert.throws(() => {
+      client.fromJSON(j);
+    });
+  });
+
+  it('fromJson should create JWT with client_email', () => {
+    client.fromJSON(json);
+    assert.strictEqual(json.client_email, client.email);
+  });
+
+  it('fromJson should create JWT with private_key', () => {
+    client.fromJSON(json);
+    assert.strictEqual(json.private_key, client.key);
+  });
+
+  it('fromJson should create JWT with private_key_id', () => {
+    client.fromJSON(json);
+    assert.strictEqual(json.private_key_id, client.keyId);
+  });
+
+  it('fromStream should error on null stream', done => {
     // Test verifies invalid parameter tests, which requires cast to any.
     // tslint:disable-next-line no-any
-    (client as any).fromJSON(null);
+    (client as any).fromStream(null, (err: Error) => {
+      assert.strictEqual(true, err instanceof Error);
+      done();
+    });
   });
-});
 
-it('fromJson should error on empty json', () => {
-  assert.throws(() => {
-    client.fromJSON({});
+  it('fromStream should construct a JWT Header instance from a stream', async () => {
+    // Read the contents of the file into a json object.
+    const fileContents = fs.readFileSync(
+      './test/fixtures/private.json',
+      'utf-8'
+    );
+    const json = JSON.parse(fileContents);
+
+    // Now open a stream on the same file.
+    const stream = fs.createReadStream('./test/fixtures/private.json');
+
+    // And pass it into the fromStream method.
+    await client.fromStream(stream);
+    // Ensure that the correct bits were pulled from the stream.
+    assert.strictEqual(json.private_key, client.key);
+    assert.strictEqual(json.client_email, client.email);
   });
-});
-
-it('fromJson should error on missing client_email', () => {
-  const j = Object.assign({}, json);
-  delete j.client_email;
-  assert.throws(() => {
-    client.fromJSON(j);
-  });
-});
-
-it('fromJson should error on missing private_key', () => {
-  const j = Object.assign({}, json);
-  delete j.private_key;
-  assert.throws(() => {
-    client.fromJSON(j);
-  });
-});
-
-it('fromJson should create JWT with client_email', () => {
-  client.fromJSON(json);
-  assert.strictEqual(json.client_email, client.email);
-});
-
-it('fromJson should create JWT with private_key', () => {
-  client.fromJSON(json);
-  assert.strictEqual(json.private_key, client.key);
-});
-
-it('fromJson should create JWT with private_key_id', () => {
-  client.fromJSON(json);
-  assert.strictEqual(json.private_key_id, client.keyId);
-});
-
-it('fromStream should error on null stream', done => {
-  // Test verifies invalid parameter tests, which requires cast to any.
-  // tslint:disable-next-line no-any
-  (client as any).fromStream(null, (err: Error) => {
-    assert.strictEqual(true, err instanceof Error);
-    done();
-  });
-});
-
-it('fromStream should construct a JWT Header instance from a stream', async () => {
-  // Read the contents of the file into a json object.
-  const fileContents = fs.readFileSync('./test/fixtures/private.json', 'utf-8');
-  const json = JSON.parse(fileContents);
-
-  // Now open a stream on the same file.
-  const stream = fs.createReadStream('./test/fixtures/private.json');
-
-  // And pass it into the fromStream method.
-  await client.fromStream(stream);
-  // Ensure that the correct bits were pulled from the stream.
-  assert.strictEqual(json.private_key, client.key);
-  assert.strictEqual(json.client_email, client.email);
-});
-
-it('should warn about deprecation of getRequestMetadata', () => {
-  const client = new JWTAccess(email, keys.private);
-  const stub = sandbox.stub(messages, 'warn');
-  // tslint:disable-next-line deprecation
-  client.getRequestMetadata(testUri);
-  assert.strictEqual(stub.calledOnce, true);
 });

--- a/test/test.oauth2.ts
+++ b/test/test.oauth2.ts
@@ -865,22 +865,6 @@ describe(__filename, () => {
     });
   });
 
-  it('should emit warning on refreshAccessToken', async () => {
-    let warned = false;
-    sandbox.stub(process, 'emitWarning').callsFake(() => (warned = true));
-    client.refreshAccessToken((err, result) => {
-      assert.strictEqual(warned, true);
-    });
-  });
-
-  it('should return error in callback on refreshAccessToken', done => {
-    client.refreshAccessToken((err, result) => {
-      assert.strictEqual(err!.message, 'No refresh token is set.');
-      assert.strictEqual(result, undefined);
-      done();
-    });
-  });
-
   function mockExample() {
     return [
       nock(baseUrl)
@@ -1254,14 +1238,6 @@ describe(__filename, () => {
     assert.strictEqual(info.aud, tokenInfo.aud);
     assert.strictEqual(info.user_id, tokenInfo.user_id);
     assert.deepStrictEqual(info.scopes, tokenInfo.scope.split(' '));
-  });
-
-  it('should warn about deprecation of getRequestMetadata', done => {
-    const stub = sandbox.stub(messages, 'warn');
-    client.getRequestMetadata(null, () => {
-      assert.strictEqual(stub.calledOnce, true);
-      done();
-    });
   });
 
   it('should throw if tries to refresh but no refresh token is available', async () => {


### PR DESCRIPTION
BREAKING CHANGE: The following deprecated methods have been removed:
- `Compute.createScopedRequired`
- `GoogleAuth.getDefaultProjectId`
- `IamAuth.createScopedRequired`
- `IamAuth.getRequestMetadata`
- `JWTAccess.createScopedRequired`
- `JWTAccess.getRequestMetadata`
- `JWTClient.createScopedRequired`
- `OAuth2Client.refreshAccessToken`
- `OAuth2Client.getRequestMetadata`

*Note: this is going into the next branch, and will be part of a larger refactor*