### PR TITLE
refactor!: getOptions() no longer accepts GoogleAuthOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,21 +46,22 @@ Before making your API call, you must be sure the API you're calling has been en
 
 Rather than manually creating an OAuth2 client, JWT client, or Compute client, the auth library can create the correct credential type for you, depending upon the environment your code is running under.
 
-For example, a JWT auth client will be created when your code is running on your local developer machine, and a Compute client will be created when the same code is running on Google Cloud Platform. If you need a specific set of scopes, you can pass those in the form of a string or an array into the `auth.getClient` method.
+For example, a JWT auth client will be created when your code is running on your local developer machine, and a Compute client will be created when the same code is running on Google Cloud Platform. If you need a specific set of scopes, you can pass those in the form of a string or an array to the `GoogleAuth` constructor.
 
 The code below shows how to retrieve a default credential type, depending upon the runtime environment.
 
 ```js
-const {auth} = require('google-auth-library');
+const {GoogleAuth} = require('google-auth-library');
 
 /**
  * Instead of specifying the type of client you'd like to use (JWT, OAuth2, etc)
  * this library will automatically choose the right client based on the environment.
  */
 async function main() {
-  const client = await auth.getClient({
+  const auth = new GoogleAuth({
     scopes: 'https://www.googleapis.com/auth/cloud-platform'
   });
+  const client = await auth.getClient();
   const projectId = await auth.getProjectId();
   const url = `https://www.googleapis.com/dns/v1/projects/${projectId}`;
   const res = await client.request({ url });
@@ -168,6 +169,7 @@ main().catch(console.error);
 ```
 
 #### Handling token events
+
 This library will automatically obtain an `access_token`, and automatically refresh the `access_token` if a `refresh_token` is present.  The `refresh_token` is only returned on the [first authorization](https://github.com/googleapis/google-api-nodejs-client/issues/750#issuecomment-304521450), so if you want to make sure you store it safely. An easy way to make sure you always store the most recent tokens is to use the `tokens` event:
 
 ```js

--- a/samples/adc.js
+++ b/samples/adc.js
@@ -16,15 +16,16 @@
 /**
  * Import the GoogleAuth library, and create a new GoogleAuth client.
  */
-const {auth} = require('google-auth-library');
+const {GoogleAuth} = require('google-auth-library');
 
 /**
  * Acquire a client, and make a request to an API that's enabled by default.
  */
 async function main() {
-  const client = await auth.getClient({
+  const auth = new GoogleAuth({
     scopes: 'https://www.googleapis.com/auth/cloud-platform',
   });
+  const client = await auth.getClient();
   const projectId = await auth.getProjectId();
   const url = `https://www.googleapis.com/dns/v1/projects/${projectId}`;
   const res = await client.request({url});

--- a/samples/credentials.js
+++ b/samples/credentials.js
@@ -16,7 +16,7 @@
 /**
  * Import the GoogleAuth library, and create a new GoogleAuth client.
  */
-const {auth} = require('google-auth-library');
+const {GoogleAuth} = require('google-auth-library');
 
 /**
  * This sample demonstrates passing a `credentials` object directly into the
@@ -33,13 +33,14 @@ async function main() {
       this sample.
     `);
   }
-  const client = await auth.getClient({
+  const auth = new GoogleAuth({
     credentials: {
       client_email: clientEmail,
       private_key: privateKey,
     },
     scopes: 'https://www.googleapis.com/auth/cloud-platform',
   });
+  const client = await auth.getClient();
   const projectId = await auth.getProjectId();
   const url = `https://www.googleapis.com/dns/v1/projects/${projectId}`;
   const res = await client.request({url});

--- a/samples/headers.js
+++ b/samples/headers.js
@@ -25,13 +25,14 @@ const fetch = require('node-fetch');
  * node-fetch, but you could use any HTTP client you like.
  */
 async function main() {
+  // create auth instance with custom scopes.
+  const auth = new GoogleAuth({
+    scopes: 'https://www.googleapis.com/auth/cloud-platform',
+  });
   const projectId = await auth.getProjectId();
   const url = `https://www.googleapis.com/dns/v1/projects/${projectId}`;
 
   // obtain an authenticated client
-  const auth = new GoogleAuth({
-    scopes: 'https://www.googleapis.com/auth/cloud-platform',
-  });
   const client = await auth.getClient();
   // Use the client to get authenticated request headers
   const headers = await client.getRequestHeaders();

--- a/samples/headers.js
+++ b/samples/headers.js
@@ -16,7 +16,7 @@
 /**
  * Import the GoogleAuth library, and create a new GoogleAuth client.
  */
-const {auth} = require('google-auth-library');
+const {GoogleAuth} = require('google-auth-library');
 const fetch = require('node-fetch');
 
 /**
@@ -29,10 +29,10 @@ async function main() {
   const url = `https://www.googleapis.com/dns/v1/projects/${projectId}`;
 
   // obtain an authenticated client
-  const client = await auth.getClient({
+  const auth = new GoogleAuth({
     scopes: 'https://www.googleapis.com/auth/cloud-platform',
   });
-
+  const client = await auth.getClient();
   // Use the client to get authenticated request headers
   const headers = await client.getRequestHeaders();
   console.log('Headers:');

--- a/samples/keepalive.js
+++ b/samples/keepalive.js
@@ -23,16 +23,17 @@
 /**
  * Import the GoogleAuth library, and create a new GoogleAuth client.
  */
-const {auth} = require('google-auth-library');
+const {GoogleAuth} = require('google-auth-library');
 const https = require('https');
 
 /**
  * Acquire a client, and make a request to an API that's enabled by default.
  */
 async function main() {
-  const client = await auth.getClient({
+  const auth = new GoogleAuth({
     scopes: 'https://www.googleapis.com/auth/cloud-platform',
   });
+  const client = await auth.getClient();
   const projectId = await auth.getProjectId();
   const url = `https://www.googleapis.com/dns/v1/projects/${projectId}`;
 

--- a/samples/keyfile.js
+++ b/samples/keyfile.js
@@ -16,7 +16,7 @@
 /**
  * Import the GoogleAuth library, and create a new GoogleAuth client.
  */
-const {auth} = require('google-auth-library');
+const {GoogleAuth} = require('google-auth-library');
 
 /**
  * Acquire a client, and make a request to an API that's enabled by default.
@@ -25,10 +25,11 @@ async function main(
   // Full path to the sevice account credential
   keyFile = process.env.GOOGLE_APPLICATION_CREDENTIALS
 ) {
-  const client = await auth.getClient({
+  const auth = new GoogleAuth({
     keyFile: keyFile,
     scopes: 'https://www.googleapis.com/auth/cloud-platform',
   });
+  const client = await auth.getClient();
   const projectId = await auth.getProjectId();
   const url = `https://www.googleapis.com/dns/v1/projects/${projectId}`;
   const res = await client.request({url});

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -459,7 +459,10 @@ export class GoogleAuth {
    * @param options The JWT or UserRefresh options for the client
    * @returns JWT or UserRefresh Client with data
    */
-  private _cacheClientFromJSON(json: JWTInput, options?: RefreshOptions): JWT | UserRefreshClient {
+  private _cacheClientFromJSON(
+    json: JWTInput,
+    options?: RefreshOptions
+  ): JWT | UserRefreshClient {
     let client: UserRefreshClient | JWT;
     // create either a UserRefreshClient or JWT client.
     options = options || {};
@@ -708,17 +711,11 @@ export class GoogleAuth {
   async getClient() {
     if (!this.cachedCredential) {
       if (this.jsonContent) {
-        this._cacheClientFromJSON(
-          this.jsonContent,
-          this.clientOptions
-        );
+        this._cacheClientFromJSON(this.jsonContent, this.clientOptions);
       } else if (this.keyFilename) {
         const filePath = path.resolve(this.keyFilename);
         const stream = fs.createReadStream(filePath);
-        await this.fromStreamAsync(
-          stream,
-          this.clientOptions
-        );
+        await this.fromStreamAsync(stream, this.clientOptions);
       } else {
         await this.getApplicationDefaultAsync(this.clientOptions);
       }

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -46,6 +46,8 @@ export interface CredentialCallback {
   (err: Error | null, result?: UserRefreshClient | JWT): void;
 }
 
+interface DeprecatedGetClientOptions {}
+
 export interface ADCCallback {
   (
     err: Error | null,
@@ -708,7 +710,12 @@ export class GoogleAuth {
    * Automatically obtain a client based on the provided configuration.  If no
    * options were passed, use Application Default Credentials.
    */
-  async getClient() {
+  async getClient(options?: DeprecatedGetClientOptions) {
+    if (options) {
+      throw new Error(
+        'Passing options to getClient is forbidden in v5.0.0. Use new GoogleAuth(opts) instead.'
+      );
+    }
     if (!this.cachedCredential) {
       if (this.jsonContent) {
         this._cacheClientFromJSON(this.jsonContent, this.clientOptions);

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -235,7 +235,7 @@ describe('googleauth', () => {
     const auth = new GoogleAuth({keyFilename: './test/fixtures/private.json'});
     auth.fromJSON({
       client_email: 'batman@example.com',
-      private_key: 'abc123'
+      private_key: 'abc123',
     });
     const client = (await auth.getClient()) as JWT;
     assert.strictEqual(client.email, 'hello@youarecool.com');
@@ -1149,10 +1149,7 @@ describe('googleauth', () => {
 
   it('should error when invalid keyFilename passed to getClient', async () => {
     const auth = new GoogleAuth({keyFilename: './funky/fresh.json'});
-    await assertRejects(
-      auth.getClient(),
-      /ENOENT: no such file or directory/
-    );
+    await assertRejects(auth.getClient(), /ENOENT: no such file or directory/);
   });
 
   it('should accept credentials to get a client', async () => {

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -1377,4 +1377,12 @@ describe('googleauth', () => {
       /Unable to detect a Project Id in the current environment/
     );
   });
+
+  it('should throw if options are passed to getClient()', async () => {
+    const auth = new GoogleAuth();
+    await assertRejects(
+      auth.getClient({hello: 'world'}),
+      /Passing options to getClient is forbidden in v5.0.0/
+    );
+  });
 });

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -1134,7 +1134,7 @@ describe('googleauth', () => {
 
   it('should use jsonContent if available', async () => {
     const json = createJwtJSON();
-    auth.fromJSON(json);
+    const auth = new GoogleAuth({credentials: json});
     // We know this returned a cached result if a nock scope isn't required
     const body = await auth.getCredentials();
     assert.notStrictEqual(body, null);


### PR DESCRIPTION
BREAKING CHANGE: `getOptions()` no longer accepts GoogleAuthOptions, preventing a variety of side effects caused by credentials that have already been stored in cache. `new GoogleAuth({})` should instead be used to customize options, or to instantiate multiple clients. `fromJSON()` has also been made idempotent (it no longer changes the cache). 

fixes #390