### PR TITLE
docs: use `open` instead of `opn` in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Let's take a look at a complete example.
 const {OAuth2Client} = require('google-auth-library');
 const http = require('http');
 const url = require('url');
-const opn = require('opn');
+const open = require('open');
 const destroyer = require('server-destroy');
 
 // Download your OAuth2 configuration from the Google
@@ -158,7 +158,7 @@ function getAuthenticatedClient() {
       })
       .listen(3000, () => {
         // open the browser to the authorize url to start the workflow
-        opn(authorizeUrl, {wait: false}).then(cp => cp.unref());
+        open(authorizeUrl, {wait: false}).then(cp => cp.unref());
       });
     destroyer(server);
   });


### PR DESCRIPTION
The node module `opn` has been renamed to `open`, so I've changed the example to reflect that.
