### PR TITLE
feat: allow upstream clients to opt out of User-Agent

### DIFF
--- a/src/transporters.ts
+++ b/src/transporters.ts
@@ -25,7 +25,7 @@ import {validate} from './options';
 
 // tslint:disable-next-line no-var-requires
 const pkg = require('../../package.json');
-const PRODUCT_NAME = 'google-auth-library';
+const PRODUCT_NAME = 'google-auth-library-nodejs';
 
 export interface Transporter {
   request<T>(opts: GaxiosOptions): GaxiosPromise<T>;

--- a/src/transporters.ts
+++ b/src/transporters.ts
@@ -25,7 +25,7 @@ import {validate} from './options';
 
 // tslint:disable-next-line no-var-requires
 const pkg = require('../../package.json');
-const PRODUCT_NAME = 'google-api-nodejs-client';
+const PRODUCT_NAME = 'google-auth-library';
 
 export interface Transporter {
   request<T>(opts: GaxiosOptions): GaxiosPromise<T>;
@@ -57,18 +57,19 @@ export class DefaultTransporter {
    * @return Configured options.
    */
   configure(opts: GaxiosOptions = {}): GaxiosOptions {
-    opts.headers = opts.headers || {};
+    const headers = Object.assign({}, opts.headers || {});
     if (typeof window === 'undefined') {
       // set transporter user agent if not in browser
-      const uaValue: string = opts.headers['User-Agent'];
-      if (!uaValue) {
-        opts.headers['User-Agent'] = DefaultTransporter.USER_AGENT;
+      const uaValue: string = headers['User-Agent'];
+      if (!headers.hasOwnProperty('User-Agent')) {
+        headers['User-Agent'] = DefaultTransporter.USER_AGENT;
+      } else if (!uaValue) {
+        delete headers['User-Agent'];
       } else if (!uaValue.includes(`${PRODUCT_NAME}/`)) {
-        opts.headers[
-          'User-Agent'
-        ] = `${uaValue} ${DefaultTransporter.USER_AGENT}`;
+        headers['User-Agent'] = `${uaValue} ${DefaultTransporter.USER_AGENT}`;
       }
     }
+    opts.headers = headers;
     return opts;
   }
 

--- a/test/test.transporters.ts
+++ b/test/test.transporters.ts
@@ -27,7 +27,7 @@ afterEach(() => {
 
 nock.disableNetConnect();
 
-const defaultUserAgentRE = 'google-api-nodejs-client/\\d+.\\d+.\\d+';
+const defaultUserAgentRE = 'google-auth-library/\\d+.\\d+.\\d+';
 const transporter = new DefaultTransporter();
 
 it('should set default adapter to node.js', () => {
@@ -47,7 +47,24 @@ it('should append default client user agent to the existing user agent', () => {
 });
 
 it('should not append default client user agent to the existing user agent more than once', () => {
-  const appName = 'MyTestApplication-1.0 google-api-nodejs-client/foobear';
+  const appName = 'MyTestApplication-1.0 google-auth-library/foobear';
+  const opts = transporter.configure({
+    headers: {'User-Agent': appName},
+    url: '',
+  });
+  assert.strictEqual(opts.headers!['User-Agent'], appName);
+});
+
+it('should respect an empty User-Agent, and drop the value from headers', () => {
+  const opts = transporter.configure({
+    headers: {'User-Agent': null},
+    url: '',
+  });
+  assert.strictEqual(opts.headers!.hasOwnProperty('User-Agent'), false);
+});
+
+it('should respect empty', () => {
+  const appName = 'MyTestApplication-1.0 google-auth-library/foobear';
   const opts = transporter.configure({
     headers: {'User-Agent': appName},
     url: '',

--- a/test/test.transporters.ts
+++ b/test/test.transporters.ts
@@ -27,7 +27,7 @@ afterEach(() => {
 
 nock.disableNetConnect();
 
-const defaultUserAgentRE = 'google-auth-library/\\d+.\\d+.\\d+';
+const defaultUserAgentRE = 'google-auth-library-nodejs/\\d+.\\d+.\\d+';
 const transporter = new DefaultTransporter();
 
 it('should set default adapter to node.js', () => {
@@ -47,7 +47,7 @@ it('should append default client user agent to the existing user agent', () => {
 });
 
 it('should not append default client user agent to the existing user agent more than once', () => {
-  const appName = 'MyTestApplication-1.0 google-auth-library/foobear';
+  const appName = 'MyTestApplication-1.0 google-auth-library-nodejs/foobear';
   const opts = transporter.configure({
     headers: {'User-Agent': appName},
     url: '',
@@ -64,7 +64,7 @@ it('should respect an empty User-Agent, and drop the value from headers', () => 
 });
 
 it('should respect empty', () => {
-  const appName = 'MyTestApplication-1.0 google-auth-library/foobear';
+  const appName = 'MyTestApplication-1.0 google-auth-library-nodejs/foobear';
   const opts = transporter.configure({
     headers: {'User-Agent': appName},
     url: '',


### PR DESCRIPTION
~BREAKING CHANGE: User-Agent now defaults to google-auth-library; empty User-Agent now possible.~

I've been talked out of a breaking change.