### PR TITLE
feat: populate x-goog-api-client header for auth

### DIFF
--- a/src/transporters.ts
+++ b/src/transporters.ts
@@ -68,6 +68,18 @@ export class DefaultTransporter {
           'User-Agent'
         ] = `${uaValue} ${DefaultTransporter.USER_AGENT}`;
       }
+      // track google-auth-library-nodejs version:
+      const authVersion = `auth/${pkg.version}`;
+      if (opts.headers['x-goog-api-client']) {
+        opts.headers[
+          'x-goog-api-client'
+        ] = `${opts.headers['x-goog-api-client']} ${authVersion}`;
+      } else {
+        const nodeVersion = process.version.replace(/^v/, '');
+        opts.headers[
+          'x-goog-api-client'
+        ] = `gl-node/${nodeVersion} ${authVersion}`;
+      }
     }
     return opts;
   }

--- a/test/test.transporters.ts
+++ b/test/test.transporters.ts
@@ -55,6 +55,30 @@ it('should not append default client user agent to the existing user agent more 
   assert.strictEqual(opts.headers!['User-Agent'], appName);
 });
 
+it('should add x-goog-api-client header if none exists', () => {
+  const opts = transporter.configure({
+    url: '',
+  });
+  assert(
+    /^gl-node\/[.-\w$]+ auth\/[.-\w$]+$/.test(
+      opts.headers!['x-goog-api-client']
+    )
+  );
+});
+
+it('should append to x-goog-api-client header if it exists', () => {
+  const opts = transporter.configure({
+    headers: {'x-goog-api-client': 'gdcl/1.0.0'},
+    url: '',
+  });
+  console.info(opts.headers);
+  assert(
+    /^gdcl\/[.-\w$]+ auth\/[.-\w$]+$/.test(
+      opts.headers!['x-goog-api-client']
+    )
+  );
+});
+
 it('should create a single error from multiple response errors', done => {
   const firstError = {message: 'Error 1'};
   const secondError = {message: 'Error 2'};

--- a/test/test.transporters.ts
+++ b/test/test.transporters.ts
@@ -73,9 +73,7 @@ it('should append to x-goog-api-client header if it exists', () => {
   });
   console.info(opts.headers);
   assert(
-    /^gdcl\/[.-\w$]+ auth\/[.-\w$]+$/.test(
-      opts.headers!['x-goog-api-client']
-    )
+    /^gdcl\/[.-\w$]+ auth\/[.-\w$]+$/.test(opts.headers!['x-goog-api-client'])
   );
 });
 


### PR DESCRIPTION
After various discussions, where I ultimately landed was on:

1. keeping the `User-Agent` fields as they stand, as I've been assured that they won't interfere with the new `x-goog-api-client` header field.
2. introducing the new `x-goog-api-client` header to the auth client itself, putting us in the position to track information about folks using it directly.