### PR TITLE
fix(deps): update to gcp-metadata and address envDetect performance issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "base64-js": "^1.3.0",
     "fast-text-encoding": "^1.0.0",
     "gaxios": "^2.0.0",
-    "gcp-metadata": "^2.0.0",
+    "gcp-metadata": "^3.0.0",
     "gtoken": "^4.0.0",
     "jws": "^3.1.5",
     "lru-cache": "^5.0.0"

--- a/src/auth/envDetect.ts
+++ b/src/auth/envDetect.ts
@@ -36,10 +36,12 @@ export async function getEnv() {
       env = GCPEnv.APP_ENGINE;
     } else if (isCloudFunction()) {
       env = GCPEnv.CLOUD_FUNCTIONS;
-    } else if (await isKubernetesEngine()) {
-      env = GCPEnv.KUBERNETES_ENGINE;
     } else if (await isComputeEngine()) {
-      env = GCPEnv.COMPUTE_ENGINE;
+      if (await isKubernetesEngine()) {
+        env = GCPEnv.KUBERNETES_ENGINE;
+      } else {
+        env = GCPEnv.COMPUTE_ENGINE;
+      }
     } else {
       env = GCPEnv.NONE;
     }

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -19,7 +19,7 @@ const assertRejects = require('assert-rejects');
 import * as child_process from 'child_process';
 import * as crypto from 'crypto';
 import * as fs from 'fs';
-import {BASE_PATH, HEADERS, HOST_ADDRESS} from 'gcp-metadata';
+import {BASE_PATH, HEADERS, HOST_ADDRESS, SECONDARY_HOST_ADDRESS} from 'gcp-metadata';
 import * as nock from 'nock';
 import * as os from 'os';
 import * as path from 'path';
@@ -158,21 +158,50 @@ describe('googleauth', () => {
   }
 
   function nockIsGCE() {
-    return nock(host)
+    const primary = nock(host)
       .get(instancePath)
       .reply(200, {}, HEADERS);
+    const secondary = nock(SECONDARY_HOST_ADDRESS)
+      .get(instancePath)
+      .reply(200, {}, HEADERS);
+
+    return {
+      done: () => {
+        primary.done();
+        secondary.done();
+      }
+    }
   }
 
   function nockNotGCE() {
-    return nock(host)
+    const primary = nock(host)
       .get(instancePath)
       .replyWithError({code: 'ENOTFOUND'});
+    const secondary = nock(SECONDARY_HOST_ADDRESS)
+      .get(instancePath)
+      .replyWithError({code: 'ENOTFOUND'});
+    return {
+      done: () => {
+        primary.done();
+        secondary.done();
+      }
+    }
   }
 
   function nock500GCE() {
-    return nock(host)
+    const primary = nock(host)
       .get(instancePath)
-      .reply(500);
+      .reply(500, {}, HEADERS);
+    const secondary = nock(SECONDARY_HOST_ADDRESS)
+      .get(instancePath)
+      .reply(500, {}, HEADERS);
+
+    return {
+      done: () => {
+        primary.done();
+        secondary.done();
+      }
+    }
   }
 
   function nock404GCE() {

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -19,7 +19,12 @@ const assertRejects = require('assert-rejects');
 import * as child_process from 'child_process';
 import * as crypto from 'crypto';
 import * as fs from 'fs';
-import {BASE_PATH, HEADERS, HOST_ADDRESS, SECONDARY_HOST_ADDRESS} from 'gcp-metadata';
+import {
+  BASE_PATH,
+  HEADERS,
+  HOST_ADDRESS,
+  SECONDARY_HOST_ADDRESS,
+} from 'gcp-metadata';
 import * as nock from 'nock';
 import * as os from 'os';
 import * as path from 'path';
@@ -169,8 +174,8 @@ describe('googleauth', () => {
       done: () => {
         primary.done();
         secondary.done();
-      }
-    }
+      },
+    };
   }
 
   function nockNotGCE() {
@@ -184,8 +189,8 @@ describe('googleauth', () => {
       done: () => {
         primary.done();
         secondary.done();
-      }
-    }
+      },
+    };
   }
 
   function nock500GCE() {
@@ -200,8 +205,8 @@ describe('googleauth', () => {
       done: () => {
         primary.done();
         secondary.done();
-      }
-    }
+      },
+    };
   }
 
   function nock404GCE() {


### PR DESCRIPTION
This pulls in an updated version of `gcp-metadata` which checks both IP and HOST; failing fast as soon as one of the endpoints fails to respond (this addresses issues with cloud run, vs., local environment).

Since only `gcpMetadata.isAvailable()` is currently fast pathed, this also performs a slight refactor on environment detection, we first detect `isComputeEngine()` hitting `isAvailable`, if we detect that we are in a compute engine environment, we next check if we're in kubernetes.

This results in one additional check, but improves cold-start performance in non-GCP environments drastically.

TODO: confirm with @JustinBeckwith, @stephenplusplus, etc., that `gcpMetadata.isAvailable()` is true for kubernetes.