### PR TITLE
feat: do not deprecate refreshAccessToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -399,10 +399,11 @@ const client = await auth.getClient({
 });
 ```
 
-#### The `refreshAccessToken` method has been deprecated
-The `OAuth2.refreshAccessToken` method has been deprecated.  The `getAccessToken`, `getRequestMetadata`, and `request` methods will all refresh the token if needed automatically.   There is no need to ever manually refresh the token.
+#### s`refreshAccessToken`
 
-As always, if you run into any problems... please let us know!
+`getAccessToken`, `getRequestMetadata`, and `request` methods will all refresh the token if needed automatically.
+
+You should not need to invoke `refreshAccessToken` directly except in [certain edge-cases](https://github.com/googleapis/google-auth-library-nodejs/issues/575).
 
 ### Features
 - Set private_key_id in JWT access token header like other google auth libraries. (#450)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -399,7 +399,9 @@ const client = await auth.getClient({
 });
 ```
 
-#### s`refreshAccessToken`
+#### Deprecate `refreshAccessToken`
+
+_Note: `refreshAccessToken` is no longer deprecated._
 
 `getAccessToken`, `getRequestMetadata`, and `request` methods will all refresh the token if needed automatically.
 

--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -640,7 +640,6 @@ export class OAuth2Client extends AuthClient {
   refreshAccessToken(
     callback?: RefreshAccessTokenCallback
   ): Promise<RefreshAccessTokenResponse> | void {
-    messages.warn(messages.REFRESH_ACCESS_TOKEN_DEPRECATED);
     if (callback) {
       this.refreshAccessTokenAsync().then(
         r => callback(null, r.credentials, r.res),

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -102,15 +102,6 @@ export const JWT_ACCESS_CREATE_SCOPED_DEPRECATED = {
   ].join(' '),
 };
 
-export const REFRESH_ACCESS_TOKEN_DEPRECATED = {
-  code: 'google-auth-library:DEP007',
-  type: WarningTypes.DEPRECATION,
-  message: [
-    'The `refreshAccessToken` method has been deprecated, and will be removed',
-    'in the 3.0 release of google-auth-library. Please use the `getRequestHeaders`',
-    'method instead.',
-  ].join(' '),
-};
 export const OAUTH_GET_REQUEST_METADATA_DEPRECATED = {
   code: 'google-auth-library:DEP004',
   type: WarningTypes.DEPRECATION,

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -203,16 +203,33 @@ describe('googleauth', () => {
 
     return {
       done: () => {
-        primary.done();
-        secondary.done();
+        try {
+          primary.done();
+          secondary.done();
+        } catch (err) {
+          // secondary can sometimes complete prior to primary.
+        }
       },
     };
   }
 
   function nock404GCE() {
-    return nock(host)
+    const primary = nock(host)
       .get(instancePath)
       .reply(404);
+    const secondary = nock(SECONDARY_HOST_ADDRESS)
+      .get(instancePath)
+      .reply(404);
+    return {
+      done: () => {
+        try {
+          primary.done();
+          secondary.done();
+        } catch (err) {
+          // secondary can sometimes complete prior to primary.
+        }
+      },
+    };
   }
 
   function createGetProjectIdNock(projectId = 'not-real') {

--- a/test/test.oauth2.ts
+++ b/test/test.oauth2.ts
@@ -865,11 +865,11 @@ describe(__filename, () => {
     });
   });
 
-  it('should emit warning on refreshAccessToken', async () => {
+  it('should not emit warning on refreshAccessToken', async () => {
     let warned = false;
     sandbox.stub(process, 'emitWarning').callsFake(() => (warned = true));
     client.refreshAccessToken((err, result) => {
-      assert.strictEqual(warned, true);
+      assert.strictEqual(warned, false);
     });
   });
 


### PR DESCRIPTION
In #575 @clocked0ne makes a case for it still being useful to be able to call `refreshAccessToken` in some circumstances; e.g., upstream errors our library does not yet take into account, but might be retriable.

We recently patched a [major issue with refreshing tokens](https://github.com/googleapis/google-auth-library-nodejs/pull/794), so it's my expectation that the only reason for calling `refreshAccessToken` would be edge-cases, but I agree with @clocked0ne that it's worth keeping this method available.

fixes #575