### PR TITLE
fix(deps): updats to gcp-metadata with debug option

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "base64-js": "^1.3.0",
     "fast-text-encoding": "^1.0.0",
     "gaxios": "^2.0.0",
-    "gcp-metadata": "^3.0.0",
+    "gcp-metadata": "^3.2.0",
     "gtoken": "^4.1.0",
     "jws": "^3.1.5",
     "lru-cache": "^5.0.0"


### PR DESCRIPTION
explicitly update to `gcp-metadata` version with `DEBUG_AUTH` option.