### PR TITLE
fix: don't append x-goog-api-client multiple times

### DIFF
--- a/src/transporters.ts
+++ b/src/transporters.ts
@@ -70,11 +70,14 @@ export class DefaultTransporter {
       }
       // track google-auth-library-nodejs version:
       const authVersion = `auth/${pkg.version}`;
-      if (opts.headers['x-goog-api-client']) {
+      if (
+        opts.headers['x-goog-api-client'] &&
+        !opts.headers['x-goog-api-client'].includes(authVersion)
+      ) {
         opts.headers[
           'x-goog-api-client'
         ] = `${opts.headers['x-goog-api-client']} ${authVersion}`;
-      } else {
+      } else if (!opts.headers['x-goog-api-client']) {
         const nodeVersion = process.version.replace(/^v/, '');
         opts.headers[
           'x-goog-api-client'

--- a/test/test.transporters.ts
+++ b/test/test.transporters.ts
@@ -71,9 +71,25 @@ it('should append to x-goog-api-client header if it exists', () => {
     headers: {'x-goog-api-client': 'gdcl/1.0.0'},
     url: '',
   });
-  console.info(opts.headers);
   assert(
     /^gdcl\/[.-\w$]+ auth\/[.-\w$]+$/.test(opts.headers!['x-goog-api-client'])
+  );
+});
+
+// see: https://github.com/googleapis/google-auth-library-nodejs/issues/819
+it('should not append x-goog-api-client header multiple times', () => {
+  const opts = {
+    headers: {'x-goog-api-client': 'gdcl/1.0.0'},
+    url: '',
+  };
+  let configuredOpts = transporter.configure(opts);
+  console.info(configuredOpts);
+  configuredOpts = transporter.configure(opts);
+  console.info(configuredOpts);
+  assert(
+    /^gdcl\/[.-\w$]+ auth\/[.-\w$]+$/.test(
+      configuredOpts.headers!['x-goog-api-client']
+    )
   );
 });
 


### PR DESCRIPTION
because options are passed by reference and not copied, a user specifying their own headers in gax options resulted in `x-goog-api-client` headers being appended multiple times.

fixes #819