### PR TITLE
feat: set x-goog-user-project header, with quota_project from default credentials

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-prettier": "^3.0.0",
     "execa": "^3.0.0",
-    "gts": "^1.0.0",
+    "gts": "^1.1.2",
     "is-docker": "^2.0.0",
     "js-green-licenses": "^1.0.0",
     "karma": "^4.0.0",

--- a/src/auth/credentials.ts
+++ b/src/auth/credentials.ts
@@ -39,6 +39,7 @@ export interface JWTInput {
   client_id?: string;
   client_secret?: string;
   refresh_token?: string;
+  quota_project?: string;
 }
 
 export interface CredentialBody {

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -749,10 +749,15 @@ export class GoogleAuth {
     // quota_project, stored in application_default_credentials.json, is set in
     // the x-goog-user-project header, to indicate an alternate account for
     // billing and quota:
-    if (this.jsonContent && this.jsonContent.quota_project) {
-      headers = Object.assign({}, headers, {
-        'x-goog-user-project': this.jsonContent.quota_project,
-      });
+    if (this.jsonContent?.quota_project) {
+      // If x-goog-user-project has explicitly been set in the client headers,
+      // it takes precedence.
+      headers = Object.assign(
+        {
+          'x-goog-user-project': this.jsonContent.quota_project,
+        },
+        headers
+      );
     }
     return headers;
   }

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -745,7 +745,16 @@ export class GoogleAuth {
    */
   async getRequestHeaders(url?: string) {
     const client = await this.getClient();
-    return client.getRequestHeaders(url);
+    let headers = client.getRequestHeaders(url);
+    // quota_project, stored in application_default_credentials.json, is set in
+    // the x-goog-user-project header, to indicate an alternate account for
+    // billing and quota:
+    if (this.jsonContent && this.jsonContent.quota_project) {
+      headers = Object.assign({}, headers, {
+        'x-goog-user-project': this.jsonContent.quota_project,
+      });
+    }
+    return headers;
   }
 
   /**

--- a/test/fixtures/.config/gcloud/application_default_credentials.json
+++ b/test/fixtures/.config/gcloud/application_default_credentials.json
@@ -1,0 +1,8 @@
+{
+  "client_id": "764086051850-6qr4p6gpi6hn506pt8ejuq83di341hur.apps.googleusercontent.com",
+  "client_secret": "privatekey",
+  "refresh_token": "refreshtoken",
+  "type": "authorized_user",
+  "project_id": "my-project",
+  "quota_project": "my-quota-project"
+}

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -1444,4 +1444,38 @@ describe('googleauth', () => {
       /Passing options to getClient is forbidden in v5.0.0/
     );
   });
+
+  it('getRequestHeaders() populates x-goog-user-project with quota_project if present', async () => {
+    // Fake a home directory in our fixtures path.
+    mockEnvVar('GCLOUD_PROJECT', 'my-fake-project');
+    mockEnvVar('HOME', './test/fixtures');
+    mockEnvVar('APPDATA', './test/fixtures/.config');
+    // The first time auth.getClient() is called /token endpoint is used to
+    // fetch a JWT.
+    const req = nock('https://oauth2.googleapis.com')
+      .post('/token')
+      .reply(200, {});
+
+    const auth = new GoogleAuth();
+    const headers = await auth.getRequestHeaders();
+    assert.strictEqual(headers['x-goog-user-project'], 'my-quota-project');
+    req.done();
+  });
+
+  it('getRequestHeaders() does not populate x-goog-user-project if quota_project is not present', async () => {
+    // Fake a home directory in our fixtures path.
+    mockEnvVar('GCLOUD_PROJECT', 'my-fake-project');
+    mockEnvVar('HOME', './test/fixtures');
+    mockEnvVar('APPDATA', './test/fixtures/.config');
+    // The first time auth.getClient() is called /token endpoint is used to
+    // fetch a JWT.
+    const req = nock('https://oauth2.googleapis.com')
+      .post('/token')
+      .reply(200, {});
+
+    const auth = new GoogleAuth();
+    const headers = await auth.getRequestHeaders();
+    assert.strictEqual(headers['x-goog-user-project'], 'my-quota-project');
+    req.done();
+  });
 });

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -1474,8 +1474,12 @@ describe('googleauth', () => {
       .reply(200, {});
 
     const auth = new GoogleAuth();
+    // Force jsonContent to load, and then remove the quota_project parameter.
+    await auth.getClient();
+    delete auth.jsonContent!.quota_project;
+
     const headers = await auth.getRequestHeaders();
-    assert.strictEqual(headers['x-goog-user-project'], 'my-quota-project');
+    assert.strictEqual(headers['x-goog-user-project'], undefined);
     req.done();
   });
 });


### PR DESCRIPTION
If the `quota_project` parameter is set, kicks it along in the request header `x-goog-user-project`.