### PR TITLE
feat: make x-goog-user-project work for additional auth clients

### DIFF
--- a/src/auth/authclient.ts
+++ b/src/auth/authclient.ts
@@ -23,6 +23,7 @@ export declare interface AuthClient {
 }
 
 export abstract class AuthClient extends EventEmitter {
+  protected quotaProjectId?: string;
   transporter = new DefaultTransporter();
   credentials: Credentials = {};
 
@@ -36,5 +37,28 @@ export abstract class AuthClient extends EventEmitter {
    */
   setCredentials(credentials: Credentials) {
     this.credentials = credentials;
+  }
+
+  /**
+   * Append additional headers, e.g., x-goog-user-project, shared across the
+   * classes inheriting AuthClient. This method should be used by any method
+   * that overrides getRequestMetadataAsync(), which is a shared helper for
+   * setting request information in both gRPC and HTTP API calls.
+   *
+   * @param headers objedcdt to append additional headers to.
+   */
+  protected addSharedMetadataHeaders(headers: {
+    [key: string]: string;
+  }): {[key: string]: string} {
+    // quota_project_id, stored in application_default_credentials.json, is set in
+    // the x-goog-user-project header, to indicate an alternate account for
+    // billing and quota:
+    if (
+      !headers['x-goog-user-project'] && // don't override a value the user sets.
+      this.quotaProjectId
+    ) {
+      headers['x-goog-user-project'] = this.quotaProjectId;
+    }
+    return headers;
   }
 }

--- a/src/auth/authclient.ts
+++ b/src/auth/authclient.ts
@@ -17,6 +17,7 @@ import {GaxiosOptions, GaxiosPromise} from 'gaxios';
 
 import {DefaultTransporter} from '../transporters';
 import {Credentials} from './credentials';
+import {Headers} from './oauth2client';
 
 export declare interface AuthClient {
   on(event: 'tokens', listener: (tokens: Credentials) => void): this;
@@ -47,9 +48,7 @@ export abstract class AuthClient extends EventEmitter {
    *
    * @param headers objedcdt to append additional headers to.
    */
-  protected addSharedMetadataHeaders(headers: {
-    [key: string]: string;
-  }): {[key: string]: string} {
+  protected addSharedMetadataHeaders(headers: Headers): Headers {
     // quota_project_id, stored in application_default_credentials.json, is set in
     // the x-goog-user-project header, to indicate an alternate account for
     // billing and quota:

--- a/src/auth/jwtclient.ts
+++ b/src/auth/jwtclient.ts
@@ -128,7 +128,11 @@ export class JWT extends OAuth2Client {
         }).target_audience
       ) {
         const {tokens} = await this.refreshToken();
-        return {headers: {Authorization: `Bearer ${tokens.id_token}`}};
+        return {
+          headers: this.addSharedMetadataHeaders({
+            Authorization: `Bearer ${tokens.id_token}`,
+          }),
+        };
       } else {
         // no scopes have been set, but a uri has been provided. Use JWTAccess
         // credentials.
@@ -139,7 +143,7 @@ export class JWT extends OAuth2Client {
           url,
           this.additionalClaims
         );
-        return {headers};
+        return {headers: this.addSharedMetadataHeaders(headers)};
       }
     } else {
       return super.getRequestMetadataAsync(url);

--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -383,7 +383,6 @@ export class OAuth2Client extends AuthClient {
   private certificateCache: Certificates = {};
   private certificateExpiry: Date | null = null;
   private certificateCacheFormat: CertificateFormat = CertificateFormat.PEM;
-  protected quotaProjectId?: string;
   protected refreshTokenPromises = new Map<string, Promise<GetTokenResponse>>();
 
   // TODO: refactor tests to make this private
@@ -808,18 +807,7 @@ export class OAuth2Client extends AuthClient {
     const headers: {[index: string]: string} = {
       Authorization: credentials.token_type + ' ' + tokens.access_token,
     };
-
-    // quota_project_id, stored in application_default_credentials.json, is set in
-    // the x-goog-user-project header, to indicate an alternate account for
-    // billing and quota:
-    if (
-      !headers['x-goog-user-project'] && // don't override a value the user sets.
-      this.quotaProjectId
-    ) {
-      headers['x-goog-user-project'] = this.quotaProjectId;
-    }
-
-    return {headers, res: r.res};
+    return {headers: this.addSharedMetadataHeaders(headers), res: r.res};
   }
 
   /**

--- a/test/fixtures/service-account-with-quota.json
+++ b/test/fixtures/service-account-with-quota.json
@@ -2,7 +2,6 @@
     "type": "service_account",
     "project_id": "my-account",
     "private_key_id": "abc123",
-    "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIICXAIBAAKBgQDI+tbB7kfmWFsD6Y+GUzRazzE62JbajO806zYVJrIx9TsmPx/E\nzfHVJy2hlONaSOfKJD7udT1w4bVo+OpWkMvXYAiqZFg+4EAg+FvuBzToyD2VyiqZ\n6hOXT3xVzPFLJDwpATm7SvGmzIbhAHLOH6QBePEw1ADhyXW2sHZbzzwEmwIDAQAB\nAoGBAJcmTy06j0hlWs3uccqL+OvytwuSqKFlLOGXo+z0VT/NNtbk0neoix/Lfz3u\nQ6469lfIOqwL8FFc7por2dGQxDu42yO2FVSaKkgNKZz2BIv64sZkKiSvMB/eScBe\nRBsUClBd828jShDlAaOucyoDqajop9EfiuysBPjSLo7Li4MBAkEA6h/tFUeyM0hv\n5OuoZU+gUTCVBGePaBFjarS1ufq8XiIIG9UPDIDGaYnBjWYJmodojwiigJ7glidc\nxV0yfu3kywJBANvCHT7QAXrnTw7xPMin0VbazUujf7fgTSpUM5/CMhI9AlAJZhx8\np8xPJG9mOd44lFS765IwHupVLqA5sPgUNXECQH3cAdihvUNiWnymztT/tEBRLJq8\njVQ1nMs9MEA1cVPtWYyUwc1H4OHVY05/HwSKbIQP8UPRpQwzRuT2j/G6M3cCQCbj\nEaPE0Q47kjzVqWjkcWHKNBvXYcla8qyz27LAfXXGv/sDvsL5uAOqWYsw7rqJDo5z\n9nqW81GKI0cNDmjHwrECQGnF6BaF1SvKw/kbKeF34OVw5FQOmmGZP5y3b49wC8Rp\nhGrm3z7yM8jiQIywqpv5KDBKKMiKMR5pIcbxscalY4k=\n-----END RSA PRIVATE KEY-----\n",
     "client_email": "fake@example.com",
     "client_id": "222222222222222222222",
     "auth_uri": "https://accounts.google.com/o/oauth2/auth",

--- a/test/fixtures/service-account-with-quota.json
+++ b/test/fixtures/service-account-with-quota.json
@@ -11,3 +11,4 @@
     "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/fake@example.com",
     "quota_project_id": "fake-quota-project"
   }
+  

--- a/test/fixtures/service-account-with-quota.json
+++ b/test/fixtures/service-account-with-quota.json
@@ -11,4 +11,3 @@
     "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/fake@example.com",
     "quota_project_id": "fake-quota-project"
   }
-  

--- a/test/fixtures/service-account-with-quota.json
+++ b/test/fixtures/service-account-with-quota.json
@@ -1,0 +1,13 @@
+{
+    "type": "service_account",
+    "project_id": "my-account",
+    "private_key_id": "abc123",
+    "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIICXAIBAAKBgQDI+tbB7kfmWFsD6Y+GUzRazzE62JbajO806zYVJrIx9TsmPx/E\nzfHVJy2hlONaSOfKJD7udT1w4bVo+OpWkMvXYAiqZFg+4EAg+FvuBzToyD2VyiqZ\n6hOXT3xVzPFLJDwpATm7SvGmzIbhAHLOH6QBePEw1ADhyXW2sHZbzzwEmwIDAQAB\nAoGBAJcmTy06j0hlWs3uccqL+OvytwuSqKFlLOGXo+z0VT/NNtbk0neoix/Lfz3u\nQ6469lfIOqwL8FFc7por2dGQxDu42yO2FVSaKkgNKZz2BIv64sZkKiSvMB/eScBe\nRBsUClBd828jShDlAaOucyoDqajop9EfiuysBPjSLo7Li4MBAkEA6h/tFUeyM0hv\n5OuoZU+gUTCVBGePaBFjarS1ufq8XiIIG9UPDIDGaYnBjWYJmodojwiigJ7glidc\nxV0yfu3kywJBANvCHT7QAXrnTw7xPMin0VbazUujf7fgTSpUM5/CMhI9AlAJZhx8\np8xPJG9mOd44lFS765IwHupVLqA5sPgUNXECQH3cAdihvUNiWnymztT/tEBRLJq8\njVQ1nMs9MEA1cVPtWYyUwc1H4OHVY05/HwSKbIQP8UPRpQwzRuT2j/G6M3cCQCbj\nEaPE0Q47kjzVqWjkcWHKNBvXYcla8qyz27LAfXXGv/sDvsL5uAOqWYsw7rqJDo5z\n9nqW81GKI0cNDmjHwrECQGnF6BaF1SvKw/kbKeF34OVw5FQOmmGZP5y3b49wC8Rp\nhGrm3z7yM8jiQIywqpv5KDBKKMiKMR5pIcbxscalY4k=\n-----END RSA PRIVATE KEY-----\n",
+    "client_email": "fake@example.com",
+    "client_id": "222222222222222222222",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://oauth2.googleapis.com/token",
+    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+    "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/fake@example.com",
+    "quota_project_id": "fake-quota-project"
+  }

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -1469,6 +1469,7 @@ describe('googleauth', () => {
     );
     const auth = new GoogleAuth();
     const client = await auth.getClient();
+    assert(client instanceof UserRefreshClient);
     const headers = await client.getRequestHeaders();
     assert.strictEqual(headers['x-goog-user-project'], 'my-quota-project');
     tokenReq.done();
@@ -1480,6 +1481,7 @@ describe('googleauth', () => {
     );
     const auth = new GoogleAuth();
     const client = await auth.getClient();
+    assert(client instanceof UserRefreshClient);
     const apiReq = nock(BASE_URL)
       .post(ENDPOINT)
       .reply(function(uri) {

--- a/test/test.jwt.ts
+++ b/test/test.jwt.ts
@@ -812,17 +812,20 @@ it('getCredentials should handle a json keyFile', async () => {
 });
 
 it('getRequestHeaders populates x-goog-user-project for JWT client', async () => {
-  // The first time auth.getClient() is called /token endpoint is used to
-  // fetch a JWT.
-  const tokenReq = nock('https://www.googleapis.com')
-    .post('/oauth2/v4/token')
-    .reply(200, {});
   const auth = new GoogleAuth({
-    credentials: require('../../test/fixtures/service-account-with-quota.json'),
+    credentials: Object.assign(
+      require('../../test/fixtures/service-account-with-quota.json'),
+      {
+        private_key: keypair(1024 /* bitsize of private key */).private,
+      }
+    ),
   });
   const client = await auth.getClient();
   assert(client instanceof JWT);
-  const headers = await client.getRequestHeaders();
+  // If a URL isn't provided to authorize, the OAuth2Client super class is
+  // executed, which was already exercised.
+  const headers = await client.getRequestHeaders(
+    'http:/example.com/my_test_service'
+  );
   assert.strictEqual(headers['x-goog-user-project'], 'fake-quota-project');
-  tokenReq.done();
 });


### PR DESCRIPTION
`quota_project_id` was not working for JWT clients, which are easier to test in our integration environment (which authenticates based on a service account, set in `GOOGLE_APPLICATION_CREDENTIALS`).

This PR:

1. pulls the logic for populating additional special headers into the `AuthClient` base class.
2. adds tests to make sure we're getting returned the types of client instances we expect, and that `x-goog-user-project` is populated for a `JWT` client.