### PR TITLE
feat: cache results of getEnv()

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "base64-js": "^1.3.0",
     "fast-text-encoding": "^1.0.0",
     "gaxios": "^2.1.0",
-    "gcp-metadata": "^3.2.0",
+    "gcp-metadata": "^3.3.0",
     "gtoken": "^4.1.0",
     "jws": "^3.1.5",
     "lru-cache": "^5.0.0"

--- a/src/auth/envDetect.ts
+++ b/src/auth/envDetect.ts
@@ -37,7 +37,7 @@ export async function getEnv() {
 }
 
 async function getEnvMemoized(): Promise<GCPEnv> {
-  let env: GCPEnv | undefined;
+  let env = GCPEnv.NONE;
   if (isAppEngine()) {
     env = GCPEnv.APP_ENGINE;
   } else if (isCloudFunction()) {

--- a/src/auth/envDetect.ts
+++ b/src/auth/envDetect.ts
@@ -22,27 +22,34 @@ export enum GCPEnv {
   NONE = 'NONE',
 }
 
-let env: GCPEnv | undefined;
+let envPromise: Promise<GCPEnv> | undefined;
 
 export function clear() {
-  env = undefined;
+  envPromise = undefined;
 }
 
 export async function getEnv() {
-  if (!env) {
-    if (isAppEngine()) {
-      env = GCPEnv.APP_ENGINE;
-    } else if (isCloudFunction()) {
-      env = GCPEnv.CLOUD_FUNCTIONS;
-    } else if (await isComputeEngine()) {
-      if (await isKubernetesEngine()) {
-        env = GCPEnv.KUBERNETES_ENGINE;
-      } else {
-        env = GCPEnv.COMPUTE_ENGINE;
-      }
+  if (envPromise) {
+    return envPromise;
+  }
+  envPromise = getEnvMemoized();
+  return envPromise;
+}
+
+async function getEnvMemoized(): Promise<GCPEnv> {
+  let env: GCPEnv | undefined;
+  if (isAppEngine()) {
+    env = GCPEnv.APP_ENGINE;
+  } else if (isCloudFunction()) {
+    env = GCPEnv.CLOUD_FUNCTIONS;
+  } else if (await isComputeEngine()) {
+    if (await isKubernetesEngine()) {
+      env = GCPEnv.KUBERNETES_ENGINE;
     } else {
-      env = GCPEnv.NONE;
+      env = GCPEnv.COMPUTE_ENGINE;
     }
+  } else {
+    env = GCPEnv.NONE;
   }
   return env;
 }

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -22,6 +22,7 @@ import {
   HEADERS,
   HOST_ADDRESS,
   SECONDARY_HOST_ADDRESS,
+  resetIsAvailableCache
 } from 'gcp-metadata';
 import * as nock from 'nock';
 import * as os from 'os';
@@ -80,6 +81,7 @@ describe('googleauth', () => {
   let createLinuxWellKnownStream: Function;
   let createWindowsWellKnownStream: Function;
   beforeEach(() => {
+    resetIsAvailableCache();
     auth = new GoogleAuth();
     exposeWindowsWellKnownFile = false;
     exposeLinuxWellKnownFile = false;
@@ -1289,6 +1291,26 @@ describe('googleauth', () => {
     const scope = nock(host)
       .get(`${instancePath}/attributes/cluster-name`)
       .reply(200, {}, HEADERS);
+    const env = await auth.getEnv();
+    assert.strictEqual(env, envDetect.GCPEnv.KUBERNETES_ENGINE);
+    scope.done();
+  });
+
+  it('should cache prior call to getEnv(), when GCE', async () => {
+    envDetect.clear();
+    const {auth, scopes} = mockGCE();
+    auth.getEnv();
+    const env = await auth.getEnv();
+    assert.strictEqual(env, envDetect.GCPEnv.COMPUTE_ENGINE);
+  });
+
+  it('should cache prior call to getEnv(), when GKE', async () => {
+    envDetect.clear();
+    const {auth, scopes} = mockGCE();
+    const scope = nock(host)
+      .get(`${instancePath}/attributes/cluster-name`)
+      .reply(200, {}, HEADERS);
+    auth.getEnv();
     const env = await auth.getEnv();
     assert.strictEqual(env, envDetect.GCPEnv.KUBERNETES_ENGINE);
     scope.done();

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -22,7 +22,7 @@ import {
   HEADERS,
   HOST_ADDRESS,
   SECONDARY_HOST_ADDRESS,
-  resetIsAvailableCache
+  resetIsAvailableCache,
 } from 'gcp-metadata';
 import * as nock from 'nock';
 import * as os from 'os';


### PR DESCRIPTION
This fixes failing tests caused by introducing caching to [gcp-metadata](https://github.com/googleapis/gcp-metadata/pull/274).

Taking a page fro `gcp-metadata`, this now also caches the promise returned by `getEnv` rather than its value, such that multiple libraries instantiated at the same time will not result in multiple enqueued promises.