### PR TITLE
fix: ensures GCE metadata sets email field for ID tokens

### DIFF
--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -109,7 +109,7 @@ export class Compute extends OAuth2Client {
   async fetchIdToken(targetAudience: string): Promise<string> {
     const idTokenPath =
       `service-accounts/${this.serviceAccountEmail}/identity` +
-      `?audience=${targetAudience}`;
+      `?format=full&audience=${targetAudience}`;
     let idToken: string;
     try {
       const instanceOptions: gcpMetadata.Options = {

--- a/test/test.compute.ts
+++ b/test/test.compute.ts
@@ -235,7 +235,7 @@ it('should accept a custom service account', async () => {
 
 it('should request the identity endpoint for fetchIdToken', async () => {
   const targetAudience = 'a-target-audience';
-  const path = `${identityPath}?audience=${targetAudience}`;
+  const path = `${identityPath}?format=full&audience=${targetAudience}`;
 
   const tokenFetchNock = nock(HOST_ADDRESS)
     .get(path, undefined, {reqheaders: HEADERS})
@@ -251,7 +251,7 @@ it('should request the identity endpoint for fetchIdToken', async () => {
 
 it('should throw an error if metadata server is unavailable', async () => {
   const targetAudience = 'a-target-audience';
-  const path = `${identityPath}?audience=${targetAudience}`;
+  const path = `${identityPath}?format=full&audience=${targetAudience}`;
 
   const tokenFetchNock = nock(HOST_ADDRESS)
     .get(path, undefined, {reqheaders: HEADERS})


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-auth-library-nodejs/issues/792#issuecomment-574555006 by adding `format=full` onto the metadata request.

The GCE metadata server in particular does not populate the `email` field of the ID Token JWT without it.