### PR TITLE
fix: populate credentials.refresh_token if provided

### DIFF
--- a/src/auth/refreshclient.ts
+++ b/src/auth/refreshclient.ts
@@ -67,6 +67,7 @@ export class UserRefreshClient extends OAuth2Client {
       forceRefreshOnFailure: opts.forceRefreshOnFailure,
     });
     this._refreshToken = opts.refreshToken;
+    this.credentials.refresh_token = opts.refreshToken;
   }
 
   /**

--- a/test/test.refresh.ts
+++ b/test/test.refresh.ts
@@ -28,6 +28,13 @@ function createJSON() {
   };
 }
 
+it('populates credentials.refresh_token if provided', () => {
+  const refresh = new UserRefreshClient({
+    refreshToken: 'abc123',
+  });
+  assert.strictEqual(refresh.credentials.refresh_token, 'abc123');
+});
+
 it('fromJSON should error on null json', () => {
   const refresh = new UserRefreshClient();
   assert.throws(() => {


### PR DESCRIPTION
If someone instantiates a UserRefreshClient directly, I couldn't see any reason to not set the refresh token, I confirmed that the client in turn refreshes on the first request.

fixes: #770

