### PR TITLE
fix: if GCF environment detected, increase library timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ecdsa-sig-formatter": "^1.0.11",
     "fast-text-encoding": "^1.0.0",
     "gaxios": "^2.1.0",
-    "gcp-metadata": "^3.3.0",
+    "gcp-metadata": "^3.4.0",
     "gtoken": "^4.1.0",
     "jws": "^4.0.0",
     "lru-cache": "^5.0.0"


### PR DESCRIPTION
this should help mitigate the issue in #798, in practice throttled network requests seem to eventually complete successfully (it just takes much longer, e.g., 2.5 minutes for 150 concurrent requests in testing).

[gapic-generator-typescript#287](https://github.com/googleapis/gapic-generator-typescript/issues/287) proposes a better solution, which moves asynchronous logic away from the global scope.