### PR TITLE
fix: do not warn for SDK creds

### DIFF
--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -379,7 +379,6 @@ export class GoogleAuth {
       location,
       options
     );
-    this.warnOnProblematicCredentials(client as JWT);
     return client;
   }
 
@@ -416,17 +415,6 @@ export class GoogleAuth {
     // Now open a read stream on the file, and parse it.
     const readStream = fs.createReadStream(filePath);
     return this.fromStream(readStream, options);
-  }
-
-  /**
-   * Credentials from the Cloud SDK that are associated with Cloud SDK's project
-   * are problematic because they may not have APIs enabled and have limited
-   * quota. If this is the case, warn about it.
-   */
-  protected warnOnProblematicCredentials(client: JWT) {
-    if (client.email === CLOUD_SDK_CLIENT_ID) {
-      messages.warn(messages.PROBLEMATIC_CREDENTIALS_WARNING);
-    }
   }
 
   /**

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -41,19 +41,6 @@ export interface Warning {
   warned?: boolean;
 }
 
-export const PROBLEMATIC_CREDENTIALS_WARNING = {
-  code: 'google-auth-library:00001',
-  type: WarningTypes.WARNING,
-  message: [
-    'Your application has authenticated using end user credentials from Google',
-    'Cloud SDK. We recommend that most server applications use service accounts',
-    'instead. If your application continues to use end user credentials from',
-    'Cloud SDK, you might receive a "quota exceeded" or "API not enabled" error.',
-    'For more information about service accounts, see',
-    'https://cloud.google.com/docs/authentication/.',
-  ].join(' '),
-};
-
 export const DEFAULT_PROJECT_ID_DEPRECATED = {
   code: 'google-auth-library:DEP002',
   type: WarningTypes.DEPRECATION,

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -1407,30 +1407,6 @@ describe('googleauth', () => {
       assert.strictEqual(value, signature);
     });
 
-    // tslint:disable-next-line ban
-    it.skip('should warn the user if using default Cloud SDK credentials', done => {
-      exposeLinuxWellKnownFile = true;
-      createLinuxWellKnownStream = () =>
-        fs.createReadStream('./test/fixtures/wellKnown.json');
-      sandbox
-        .stub(process, 'emitWarning')
-        .callsFake((message, warningOrType) => {
-          assert.strictEqual(
-            message,
-            messages.PROBLEMATIC_CREDENTIALS_WARNING.message
-          );
-          const warningType =
-            typeof warningOrType === 'string'
-              ? warningOrType
-              : // @types/node doesn't recognize the emitWarning syntax which
-                // tslint:disable-next-line no-any
-                (warningOrType as any).type;
-          assert.strictEqual(warningType, messages.WarningTypes.WARNING);
-          done();
-        });
-      auth._tryGetApplicationCredentialsFromWellKnownFile();
-    });
-
     it('should warn the user if using the getDefaultProjectId method', done => {
       mockEnvVar('GCLOUD_PROJECT', STUB_PROJECT);
       sandbox


### PR DESCRIPTION
We used to warn users when relying on a token provided by `gcloud auth application-default login`.  We are headed down a road where this is the default behavior (again), and probably don't need to warn users anymore.  Especially since the docs don't ask you to do it anymore.  

Fixes #833 somewhat bluntly