### PR TITLE
fix: gcp-metadata now warns rather than throwing

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ecdsa-sig-formatter": "^1.0.11",
     "fast-text-encoding": "^1.0.0",
     "gaxios": "^3.0.0",
-    "gcp-metadata": "^4.0.0",
+    "gcp-metadata": "^4.1.0",
     "gtoken": "^5.0.0",
     "jws": "^4.0.0",
     "lru-cache": "^5.0.0"

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -1045,11 +1045,11 @@ describe('googleauth', () => {
       scopes.forEach(s => s.done());
     });
 
-    it('_checkIsGCE should throw on unexpected errors', async () => {
+    it('_checkIsGCE should return false on unexpected errors', async () => {
       assert.notStrictEqual(true, auth.isGCE);
       const scope = nock500GCE();
-      await assert.rejects(auth._checkIsGCE());
-      assert.strictEqual(undefined, auth.isGCE);
+      assert.strictEqual(await auth._checkIsGCE(), false);
+      assert.strictEqual(auth.isGCE, false);
       scope.done();
     });
 


### PR DESCRIPTION
Arguably the upstream `gcp-metadata` change, which warns rather than throwing, was breaking ... but given that these should be rare events, and our default behavior is less user-hostile now, I'm voting that it's fine to simply update this test.