### PR TITLE
fix: fixing tsc error caused by @types/node update

### DIFF
--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -1032,7 +1032,7 @@ describe('googleauth', () => {
       const scope = nockNotGCE();
       assert.notStrictEqual(true, auth.isGCE);
       await auth._checkIsGCE();
-      assert.strictEqual(false, auth.isGCE);
+      assert.strictEqual(false as boolean, auth.isGCE);
       scope.done();
     });
 
@@ -1057,7 +1057,7 @@ describe('googleauth', () => {
       assert.notStrictEqual(true, auth.isGCE);
       const scope = nockNotGCE();
       await auth._checkIsGCE();
-      assert.strictEqual(false, auth.isGCE);
+      assert.strictEqual(false as boolean, auth.isGCE);
       scope.done();
     });
 
@@ -1076,9 +1076,9 @@ describe('googleauth', () => {
       assert.notStrictEqual(true, auth.isGCE);
       const scope = nockNotGCE();
       await auth._checkIsGCE();
-      assert.strictEqual(false, auth.isGCE);
+      assert.strictEqual(false as boolean, auth.isGCE);
       await auth._checkIsGCE();
-      assert.strictEqual(false, auth.isGCE);
+      assert.strictEqual(false as boolean, auth.isGCE);
       scope.done();
     });
 

--- a/test/test.jwt.ts
+++ b/test/test.jwt.ts
@@ -393,7 +393,7 @@ describe('jwt', () => {
 
     jwt.request({url: 'http://bar'}, () => {
       assert.strictEqual('initial-access-token', jwt.credentials.access_token);
-      assert.strictEqual(false, scope.isDone());
+      assert.strictEqual(false as boolean, scope.isDone());
       done();
     });
   });
@@ -439,7 +439,7 @@ describe('jwt', () => {
 
     jwt.request({url: 'http://bar'}, () => {
       assert.strictEqual('initial-access-token', jwt.credentials.access_token);
-      assert.strictEqual(false, scope.isDone());
+      assert.strictEqual(false as boolean, scope.isDone());
       done();
     });
   });
@@ -460,7 +460,7 @@ describe('jwt', () => {
 
     jwt.request({url: 'http://bar'}, () => {
       assert.strictEqual('initial-access-token', jwt.credentials.access_token);
-      assert.strictEqual(false, scope.isDone());
+      assert.strictEqual(false as boolean, scope.isDone());
       done();
     });
   });

--- a/test/test.oauth2.ts
+++ b/test/test.oauth2.ts
@@ -1067,7 +1067,7 @@ describe('oauth2', () => {
         'initial-access-token',
         client.credentials.access_token
       );
-      assert.strictEqual(false, scopes[0].isDone());
+      assert.strictEqual(false as boolean, scopes[0].isDone());
       scopes[1].done();
     });
 
@@ -1083,7 +1083,7 @@ describe('oauth2', () => {
           'initial-access-token',
           client.credentials.access_token
         );
-        assert.strictEqual(false, scopes[0].isDone());
+        assert.strictEqual(false as boolean, scopes[0].isDone());
         scopes[1].done();
         done();
       });
@@ -1100,7 +1100,7 @@ describe('oauth2', () => {
           'initial-access-token',
           client.credentials.access_token
         );
-        assert.strictEqual(false, scopes[0].isDone());
+        assert.strictEqual(false as boolean, scopes[0].isDone());
         scopes[1].done();
         done();
       });


### PR DESCRIPTION
The recent commit https://github.com/DefinitelyTyped/DefinitelyTyped/commit/e9103792668257b6cc86cd21d6c455ecb5fae1ea to `@types/node` makes `tsc` trigger "code unreachable" error. Fixing this with a workaround as suggested in https://github.com/DefinitelyTyped/DefinitelyTyped/issues/44944.