### PR TITLE
fix(tsc): audience property is not mandatory on verifyIdToken

### DIFF
--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -384,7 +384,7 @@ export interface RevokeCredentialsResult {
 
 export interface VerifyIdTokenOptions {
   idToken: string;
-  audience: string | string[];
+  audience?: string | string[];
   maxExpiry?: number;
 }
 
@@ -1174,7 +1174,7 @@ export class OAuth2Client extends AuthClient {
   async verifySignedJwtWithCertsAsync(
     jwt: string,
     certs: Certificates | PublicKeys,
-    requiredAudience: string | string[],
+    requiredAudience?: string | string[],
     issuers?: string[],
     maxExpiry?: number
   ) {


### PR DESCRIPTION
[As code says](https://github.com/googleapis/google-auth-library-nodejs/blob/master/src/auth/oauth2client.ts#L1295), `audience` property is not mandatory on `OAuth2Client.prototype.verifyIdToken()` call despite the TypeScript interface currently requires it, so I have just updated the interface to make it optional.