### PR TITLE
fix #1037: Fix doc example mistake + add new code sample in the doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,8 +354,8 @@ const {GoogleAuth} = require('google-auth-library');
 async function main() {
   const url = 'https://cloud-run-1234-uc.a.run.app';
   const auth = new GoogleAuth();
-  const client = auth.getIdTokenClient(url);
-  const res = await client.request({url});
+  const client = await auth.getIdTokenClient(url);
+  const res = await client.request({ url, method:'GET' });
   console.log(res.data);
 }
 
@@ -375,7 +375,7 @@ async function main()
   const targetAudience = 'iap-client-id';
   const url = 'https://iap-url.com';
   const auth = new GoogleAuth();
-  const client = auth.getIdTokenClient(targetAudience);
+  const client = await auth.getIdTokenClient(targetAudience);
   const res = await client.request({url});
   console.log(res.data);
 }
@@ -384,6 +384,23 @@ main().catch(console.error);
 ```
 
 A complete example can be found in [`samples/idtokens-iap.js`](https://github.com/googleapis/google-auth-library-nodejs/blob/master/samples/idtokens-iap.js).
+
+To explicitly acquire the ID token required to make HTTP requests to protected Cloud Run services, you can use the `getRequestMetadataAsync` method.
+
+``` js
+// Make a request to a protected Cloud Run service.
+const {GoogleAuth} = require('google-auth-library');
+
+async function main() {
+  const url = 'https://cloud-run-1234-uc.a.run.app';
+  const auth = new GoogleAuth();
+  const client = await auth.getIdTokenClient(url)
+  const res = await client.getRequestMetadataAsync();
+  console.log(res.headers);
+}
+
+main().catch(console.error);
+```
 
 ### Verifying ID Tokens
 


### PR DESCRIPTION
fix #1037: Fix a mistake in the doc's code example (missing await) an add new example on how to retrieve an ID token explicitly to use it to request protected Cloud Run services.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-auth-library-nodejs/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #1037 🦕
