### PR TITLE
docs: correct spelling of its

### DIFF
--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -545,7 +545,7 @@ export class OAuth2Client extends AuthClient {
   }
 
   /**
-   * Convenience method to automatically generate a code_verifier, and it's
+   * Convenience method to automatically generate a code_verifier, and its
    * resulting SHA256. If used, this must be paired with a S256
    * code_challenge_method.
    *


### PR DESCRIPTION
Minor change that fixes a spelling error. I don't think an issue needed to be opened for this. Thanks!