### PR TITLE
feat: default self-signed JWTs

### DIFF
--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -27,7 +27,7 @@ import {Compute, ComputeOptions} from './computeclient';
 import {CredentialBody, JWTInput} from './credentials';
 import {IdTokenClient} from './idtokenclient';
 import {GCPEnv, getEnv} from './envDetect';
-import {JWT, JWTOptions} from './jwtclient';
+import {JWT, JWTOptions, DefaultScopesKey} from './jwtclient';
 import {
   Headers,
   OAuth2Client,
@@ -85,7 +85,7 @@ export interface GoogleAuthOptions {
    * Scopes populated by the client library by default. We differentiate between
    * these and user defined scopes when deciding whether to use a self-signed JWT.
    */
-  defaultScopes?: string | string[];
+  [DefaultScopesKey]?: string | string[];
 
   /**
    * Required scopes for the desired API request
@@ -127,7 +127,7 @@ export class GoogleAuth {
 
   private keyFilename?: string;
   private scopes?: string | string[];
-  private defaultScopes?: string | string[];
+  private [DefaultScopesKey]?: string | string[];
   private clientOptions?: RefreshOptions;
 
   /**
@@ -139,8 +139,8 @@ export class GoogleAuth {
     opts = opts || {};
     this._cachedProjectId = opts.projectId || null;
     this.keyFilename = opts.keyFilename || opts.keyFile;
-    this.defaultScopes = opts.defaultScopes;
     this.scopes = opts.scopes;
+    this[DefaultScopesKey] = opts[DefaultScopesKey];
     this.jsonContent = opts.credentials || null;
     this.clientOptions = opts.clientOptions;
   }
@@ -252,7 +252,7 @@ export class GoogleAuth {
     );
     if (credential) {
       if (credential instanceof JWT) {
-        credential.defaultScopes = this.scopes;
+        credential[DefaultScopesKey] = this[DefaultScopesKey];
         credential.scopes = this.scopes;
       }
       this.cachedCredential = credential;
@@ -291,7 +291,7 @@ export class GoogleAuth {
 
     // For GCE, just return a default ComputeClient. It will take care of
     // the rest.
-    (options as ComputeOptions).scopes = this.scopes || this.defaultScopes;
+    (options as ComputeOptions).scopes = this.scopes || this[DefaultScopesKey];
     this.cachedCredential = new Compute(options);
     projectId = await this.getProjectId();
     return {projectId, credential: this.cachedCredential};
@@ -429,7 +429,7 @@ export class GoogleAuth {
     if (json.type === 'authorized_user') {
       client = new UserRefreshClient(options);
     } else {
-      (options as JWTOptions).defaultScopes = this.defaultScopes;
+      (options as JWTOptions)[DefaultScopesKey] = this[DefaultScopesKey];
       (options as JWTOptions).scopes = this.scopes;
       client = new JWT(options);
     }

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -27,7 +27,7 @@ import {Compute, ComputeOptions} from './computeclient';
 import {CredentialBody, JWTInput} from './credentials';
 import {IdTokenClient} from './idtokenclient';
 import {GCPEnv, getEnv} from './envDetect';
-import {JWT, JWTOptions, kDefaultScopes} from './jwtclient';
+import {JWT, JWTOptions} from './jwtclient';
 import {
   Headers,
   OAuth2Client,
@@ -82,12 +82,6 @@ export interface GoogleAuthOptions {
   clientOptions?: JWTOptions | OAuth2ClientOptions | UserRefreshClientOptions;
 
   /**
-   * Scopes populated by the client library by default. We differentiate between
-   * these and user defined scopes when deciding whether to use a self-signed JWT.
-   */
-  [kDefaultScopes]?: string | string[];
-
-  /**
    * Required scopes for the desired API request
    */
   scopes?: string | string[];
@@ -125,9 +119,14 @@ export class GoogleAuth {
 
   cachedCredential: JWT | UserRefreshClient | Compute | null = null;
 
+  /**
+   * Scopes populated by the client library by default. We differentiate between
+   * these and user defined scopes when deciding whether to use a self-signed JWT.
+   */
+  defaultScopes?: string | string[];
+
   private keyFilename?: string;
   private scopes?: string | string[];
-  private [kDefaultScopes]?: string | string[];
   private clientOptions?: RefreshOptions;
 
   /**
@@ -140,7 +139,6 @@ export class GoogleAuth {
     this._cachedProjectId = opts.projectId || null;
     this.keyFilename = opts.keyFilename || opts.keyFile;
     this.scopes = opts.scopes;
-    this[kDefaultScopes] = opts[kDefaultScopes];
     this.jsonContent = opts.credentials || null;
     this.clientOptions = opts.clientOptions;
   }
@@ -252,7 +250,7 @@ export class GoogleAuth {
     );
     if (credential) {
       if (credential instanceof JWT) {
-        credential[kDefaultScopes] = this[kDefaultScopes];
+        credential.defaultScopes = this.defaultScopes;
         credential.scopes = this.scopes;
       }
       this.cachedCredential = credential;
@@ -291,7 +289,7 @@ export class GoogleAuth {
 
     // For GCE, just return a default ComputeClient. It will take care of
     // the rest.
-    (options as ComputeOptions).scopes = this.scopes || this[kDefaultScopes];
+    (options as ComputeOptions).scopes = this.scopes || this.defaultScopes;
     this.cachedCredential = new Compute(options);
     projectId = await this.getProjectId();
     return {projectId, credential: this.cachedCredential};
@@ -429,9 +427,9 @@ export class GoogleAuth {
     if (json.type === 'authorized_user') {
       client = new UserRefreshClient(options);
     } else {
-      (options as JWTOptions)[kDefaultScopes] = this[kDefaultScopes];
       (options as JWTOptions).scopes = this.scopes;
       client = new JWT(options);
+      client.defaultScopes = this.defaultScopes;
     }
     client.fromJSON(json);
     return client;

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -82,8 +82,8 @@ export interface GoogleAuthOptions {
   clientOptions?: JWTOptions | OAuth2ClientOptions | UserRefreshClientOptions;
 
   /**
-   * Scopes populated by a client library by default. We differentiate between
-   * these and user defined scopes when determining the type of auth to use
+   * Scopes populated by the client library by default. We differentiate between
+   * these and user defined scopes when deciding whether to use a self-signed JWT.
    */
   defaultScopes?: string | string[];
 

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -264,6 +264,7 @@ export class GoogleAuth {
     );
     if (credential) {
       if (credential instanceof JWT) {
+        credential.defaultScopes = this.defaultScopes;
         credential.scopes = this.scopes;
       }
       this.cachedCredential = credential;
@@ -454,6 +455,7 @@ export class GoogleAuth {
     } else {
       (options as JWTOptions).scopes = this.scopes;
       client = new JWT(options);
+      client.defaultScopes = this.defaultScopes;
     }
     client.fromJSON(json);
     // cache both raw data used to instantiate client and client itself.

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -27,7 +27,7 @@ import {Compute, ComputeOptions} from './computeclient';
 import {CredentialBody, JWTInput} from './credentials';
 import {IdTokenClient} from './idtokenclient';
 import {GCPEnv, getEnv} from './envDetect';
-import {JWT, JWTOptions, DefaultScopesKey} from './jwtclient';
+import {JWT, JWTOptions, kDefaultScopes} from './jwtclient';
 import {
   Headers,
   OAuth2Client,
@@ -85,7 +85,7 @@ export interface GoogleAuthOptions {
    * Scopes populated by the client library by default. We differentiate between
    * these and user defined scopes when deciding whether to use a self-signed JWT.
    */
-  [DefaultScopesKey]?: string | string[];
+  [kDefaultScopes]?: string | string[];
 
   /**
    * Required scopes for the desired API request
@@ -127,7 +127,7 @@ export class GoogleAuth {
 
   private keyFilename?: string;
   private scopes?: string | string[];
-  private [DefaultScopesKey]?: string | string[];
+  private [kDefaultScopes]?: string | string[];
   private clientOptions?: RefreshOptions;
 
   /**
@@ -140,7 +140,7 @@ export class GoogleAuth {
     this._cachedProjectId = opts.projectId || null;
     this.keyFilename = opts.keyFilename || opts.keyFile;
     this.scopes = opts.scopes;
-    this[DefaultScopesKey] = opts[DefaultScopesKey];
+    this[kDefaultScopes] = opts[kDefaultScopes];
     this.jsonContent = opts.credentials || null;
     this.clientOptions = opts.clientOptions;
   }
@@ -252,7 +252,7 @@ export class GoogleAuth {
     );
     if (credential) {
       if (credential instanceof JWT) {
-        credential[DefaultScopesKey] = this[DefaultScopesKey];
+        credential[kDefaultScopes] = this[kDefaultScopes];
         credential.scopes = this.scopes;
       }
       this.cachedCredential = credential;
@@ -291,7 +291,7 @@ export class GoogleAuth {
 
     // For GCE, just return a default ComputeClient. It will take care of
     // the rest.
-    (options as ComputeOptions).scopes = this.scopes || this[DefaultScopesKey];
+    (options as ComputeOptions).scopes = this.scopes || this[kDefaultScopes];
     this.cachedCredential = new Compute(options);
     projectId = await this.getProjectId();
     return {projectId, credential: this.cachedCredential};
@@ -429,7 +429,7 @@ export class GoogleAuth {
     if (json.type === 'authorized_user') {
       client = new UserRefreshClient(options);
     } else {
-      (options as JWTOptions)[DefaultScopesKey] = this[DefaultScopesKey];
+      (options as JWTOptions)[kDefaultScopes] = this[kDefaultScopes];
       (options as JWTOptions).scopes = this.scopes;
       client = new JWT(options);
     }

--- a/src/auth/jwtaccess.ts
+++ b/src/auth/jwtaccess.ts
@@ -129,7 +129,7 @@ export class JWTAccess {
    * @param iat The issued at time for the JWT.
    * @returns An expiration time for the JWT.
    */
-  static getExpirationTime(iat: number): number {
+  private static getExpirationTime(iat: number): number {
     const exp = iat + 3600; // 3600 seconds = 1 hour
     return exp;
   }

--- a/src/auth/jwtaccess.ts
+++ b/src/auth/jwtaccess.ts
@@ -73,7 +73,7 @@ export class JWTAccess {
    */
   getRequestHeaders(url: string, additionalClaims?: Claims): Headers {
     // Return cached authorization headers, unless we are within
-    // EXPIRY_DELTA ms of them expiring:
+    // eagerRefreshThresholdMillis ms of them expiring:
     const cachedToken = this.cache.get(url);
     const now = Date.now();
     if (

--- a/src/auth/jwtclient.ts
+++ b/src/auth/jwtclient.ts
@@ -138,7 +138,12 @@ export class JWT extends OAuth2Client implements IdTokenProvider {
         // no scopes have been set, but a uri has been provided. Use JWTAccess
         // credentials.
         if (!this.access) {
-          this.access = new JWTAccess(this.email, this.key, this.keyId);
+          this.access = new JWTAccess(
+            this.email,
+            this.key,
+            this.keyId,
+            this.eagerRefreshThresholdMillis
+          );
         }
         const headers = await this.access.getRequestHeaders(
           url,

--- a/src/auth/jwtclient.ts
+++ b/src/auth/jwtclient.ts
@@ -151,8 +151,12 @@ export class JWT extends OAuth2Client implements IdTokenProvider {
         );
         return {headers: this.addSharedMetadataHeaders(headers)};
       }
-    } else {
+    } else if (this.hasAnyScopes() || this.apiKey) {
       return super.getRequestMetadataAsync(url);
+    } else {
+      // If no audience, apiKey, or scopes are provided, we should not attempt
+      // to populate any headers:
+      return {headers: {}};
     }
   }
 
@@ -186,12 +190,16 @@ export class JWT extends OAuth2Client implements IdTokenProvider {
     if (!this.scopes) {
       return false;
     }
-    // For arrays, check the array length.
-    if (this.scopes instanceof Array) {
-      return this.scopes.length > 0;
-    }
-    // For others, convert to a string and check the length.
-    return String(this.scopes).length > 0;
+    return this.scopes.length > 0;
+  }
+
+  /**
+   * Are there any default or user scopes defined.
+   */
+  private hasAnyScopes() {
+    if (this.scopes && this.scopes.length > 0) return true;
+    if (this.defaultScopes && this.defaultScopes.length > 0) return true;
+    return false;
   }
 
   /**

--- a/src/auth/jwtclient.ts
+++ b/src/auth/jwtclient.ts
@@ -25,13 +25,18 @@ import {
   RequestMetadataResponse,
 } from './oauth2client';
 
+// Default scopes are provided by GAPIC libraries to indicate that it
+// is safe to use a self-signed JWT. We hide this option behind a symbol,
+// to discourage users from setting this field:
+export const DefaultScopesKey = Symbol('default-scopes-symbol');
+
 export interface JWTOptions extends RefreshOptions {
   email?: string;
   keyFile?: string;
   key?: string;
   keyId?: string;
-  defaultScopes?: string | string[];
   scopes?: string | string[];
+  [DefaultScopesKey]?: string | string[];
   subject?: string;
   additionalClaims?: {};
 }
@@ -41,7 +46,7 @@ export class JWT extends OAuth2Client implements IdTokenProvider {
   keyFile?: string;
   key?: string;
   keyId?: string;
-  defaultScopes?: string | string[];
+  [DefaultScopesKey]?: string | string[];
   scopes?: string | string[];
   scope?: string;
   subject?: string;
@@ -92,6 +97,7 @@ export class JWT extends OAuth2Client implements IdTokenProvider {
     this.key = opts.key;
     this.keyId = opts.keyId;
     this.scopes = opts.scopes;
+    this[DefaultScopesKey] = opts[DefaultScopesKey];
     this.subject = opts.subject;
     this.additionalClaims = opts.additionalClaims;
     this.credentials = {refresh_token: 'jwt-placeholder', expiry_date: 1};
@@ -161,7 +167,7 @@ export class JWT extends OAuth2Client implements IdTokenProvider {
     const gtoken = new GoogleToken({
       iss: this.email,
       sub: this.subject,
-      scope: this.scopes || this.defaultScopes,
+      scope: this.scopes || this[DefaultScopesKey],
       keyFile: this.keyFile,
       key: this.key,
       additionalClaims: {target_audience: targetAudience},
@@ -250,7 +256,7 @@ export class JWT extends OAuth2Client implements IdTokenProvider {
       this.gtoken = new GoogleToken({
         iss: this.email,
         sub: this.subject,
-        scope: this.scopes || this.defaultScopes,
+        scope: this.scopes || this[DefaultScopesKey],
         keyFile: this.keyFile,
         key: this.key,
         additionalClaims: this.additionalClaims,

--- a/src/auth/jwtclient.ts
+++ b/src/auth/jwtclient.ts
@@ -28,7 +28,7 @@ import {
 // Default scopes are provided by GAPIC libraries to indicate that it
 // is safe to use a self-signed JWT. We hide this option behind a symbol,
 // to discourage users from setting this field:
-export const DefaultScopesKey = Symbol('default-scopes-symbol');
+export const kDefaultScopes = Symbol('default-scopes-symbol');
 
 export interface JWTOptions extends RefreshOptions {
   email?: string;
@@ -36,7 +36,7 @@ export interface JWTOptions extends RefreshOptions {
   key?: string;
   keyId?: string;
   scopes?: string | string[];
-  [DefaultScopesKey]?: string | string[];
+  [kDefaultScopes]?: string | string[];
   subject?: string;
   additionalClaims?: {};
 }
@@ -46,7 +46,7 @@ export class JWT extends OAuth2Client implements IdTokenProvider {
   keyFile?: string;
   key?: string;
   keyId?: string;
-  [DefaultScopesKey]?: string | string[];
+  [kDefaultScopes]?: string | string[];
   scopes?: string | string[];
   scope?: string;
   subject?: string;
@@ -97,7 +97,7 @@ export class JWT extends OAuth2Client implements IdTokenProvider {
     this.key = opts.key;
     this.keyId = opts.keyId;
     this.scopes = opts.scopes;
-    this[DefaultScopesKey] = opts[DefaultScopesKey];
+    this[kDefaultScopes] = opts[kDefaultScopes];
     this.subject = opts.subject;
     this.additionalClaims = opts.additionalClaims;
     this.credentials = {refresh_token: 'jwt-placeholder', expiry_date: 1};
@@ -167,7 +167,7 @@ export class JWT extends OAuth2Client implements IdTokenProvider {
     const gtoken = new GoogleToken({
       iss: this.email,
       sub: this.subject,
-      scope: this.scopes || this[DefaultScopesKey],
+      scope: this.scopes || this[kDefaultScopes],
       keyFile: this.keyFile,
       key: this.key,
       additionalClaims: {target_audience: targetAudience},
@@ -256,7 +256,7 @@ export class JWT extends OAuth2Client implements IdTokenProvider {
       this.gtoken = new GoogleToken({
         iss: this.email,
         sub: this.subject,
-        scope: this.scopes || this[DefaultScopesKey],
+        scope: this.scopes || this[kDefaultScopes],
         keyFile: this.keyFile,
         key: this.key,
         additionalClaims: this.additionalClaims,

--- a/src/auth/jwtclient.ts
+++ b/src/auth/jwtclient.ts
@@ -30,6 +30,7 @@ export interface JWTOptions extends RefreshOptions {
   keyFile?: string;
   key?: string;
   keyId?: string;
+  defaultScopes?: string | string[];
   scopes?: string | string[];
   subject?: string;
   additionalClaims?: {};
@@ -40,6 +41,7 @@ export class JWT extends OAuth2Client implements IdTokenProvider {
   keyFile?: string;
   key?: string;
   keyId?: string;
+  defaultScopes?: string | string[];
   scopes?: string | string[];
   scope?: string;
   subject?: string;
@@ -120,7 +122,7 @@ export class JWT extends OAuth2Client implements IdTokenProvider {
   protected async getRequestMetadataAsync(
     url?: string | null
   ): Promise<RequestMetadataResponse> {
-    if (!this.apiKey && !this.hasScopes() && url) {
+    if (!this.apiKey && !this.hasUserScopes() && url) {
       if (
         this.additionalClaims &&
         (this.additionalClaims as {
@@ -159,7 +161,7 @@ export class JWT extends OAuth2Client implements IdTokenProvider {
     const gtoken = new GoogleToken({
       iss: this.email,
       sub: this.subject,
-      scope: this.scopes,
+      scope: this.scopes || this.defaultScopes,
       keyFile: this.keyFile,
       key: this.key,
       additionalClaims: {target_audience: targetAudience},
@@ -176,7 +178,7 @@ export class JWT extends OAuth2Client implements IdTokenProvider {
   /**
    * Determine if there are currently scopes available.
    */
-  private hasScopes() {
+  private hasUserScopes() {
     if (!this.scopes) {
       return false;
     }
@@ -248,7 +250,7 @@ export class JWT extends OAuth2Client implements IdTokenProvider {
       this.gtoken = new GoogleToken({
         iss: this.email,
         sub: this.subject,
-        scope: this.scopes,
+        scope: this.scopes || this.defaultScopes,
         keyFile: this.keyFile,
         key: this.key,
         additionalClaims: this.additionalClaims,

--- a/src/auth/jwtclient.ts
+++ b/src/auth/jwtclient.ts
@@ -25,18 +25,12 @@ import {
   RequestMetadataResponse,
 } from './oauth2client';
 
-// Default scopes are provided by GAPIC libraries to indicate that it
-// is safe to use a self-signed JWT. We hide this option behind a symbol,
-// to discourage users from setting this field:
-export const kDefaultScopes = Symbol('default-scopes-symbol');
-
 export interface JWTOptions extends RefreshOptions {
   email?: string;
   keyFile?: string;
   key?: string;
   keyId?: string;
   scopes?: string | string[];
-  [kDefaultScopes]?: string | string[];
   subject?: string;
   additionalClaims?: {};
 }
@@ -46,7 +40,7 @@ export class JWT extends OAuth2Client implements IdTokenProvider {
   keyFile?: string;
   key?: string;
   keyId?: string;
-  [kDefaultScopes]?: string | string[];
+  defaultScopes?: string | string[];
   scopes?: string | string[];
   scope?: string;
   subject?: string;
@@ -97,7 +91,6 @@ export class JWT extends OAuth2Client implements IdTokenProvider {
     this.key = opts.key;
     this.keyId = opts.keyId;
     this.scopes = opts.scopes;
-    this[kDefaultScopes] = opts[kDefaultScopes];
     this.subject = opts.subject;
     this.additionalClaims = opts.additionalClaims;
     this.credentials = {refresh_token: 'jwt-placeholder', expiry_date: 1};
@@ -167,7 +160,7 @@ export class JWT extends OAuth2Client implements IdTokenProvider {
     const gtoken = new GoogleToken({
       iss: this.email,
       sub: this.subject,
-      scope: this.scopes || this[kDefaultScopes],
+      scope: this.scopes || this.defaultScopes,
       keyFile: this.keyFile,
       key: this.key,
       additionalClaims: {target_audience: targetAudience},
@@ -256,7 +249,7 @@ export class JWT extends OAuth2Client implements IdTokenProvider {
       this.gtoken = new GoogleToken({
         iss: this.email,
         sub: this.subject,
-        scope: this.scopes || this[kDefaultScopes],
+        scope: this.scopes || this.defaultScopes,
         keyFile: this.keyFile,
         key: this.key,
         additionalClaims: this.additionalClaims,

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ export {GoogleAuthOptions, ProjectIdCallback} from './auth/googleauth';
 export {IAMAuth, RequestMetadata} from './auth/iam';
 export {IdTokenClient, IdTokenProvider} from './auth/idtokenclient';
 export {Claims, JWTAccess} from './auth/jwtaccess';
-export {JWT, JWTOptions, kDefaultScopes} from './auth/jwtclient';
+export {JWT, JWTOptions} from './auth/jwtclient';
 export {
   Certificates,
   CodeChallengeMethod,

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ export {GoogleAuthOptions, ProjectIdCallback} from './auth/googleauth';
 export {IAMAuth, RequestMetadata} from './auth/iam';
 export {IdTokenClient, IdTokenProvider} from './auth/idtokenclient';
 export {Claims, JWTAccess} from './auth/jwtaccess';
-export {JWT, JWTOptions} from './auth/jwtclient';
+export {JWT, JWTOptions, DefaultScopesKey} from './auth/jwtclient';
 export {
   Certificates,
   CodeChallengeMethod,

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ export {GoogleAuthOptions, ProjectIdCallback} from './auth/googleauth';
 export {IAMAuth, RequestMetadata} from './auth/iam';
 export {IdTokenClient, IdTokenProvider} from './auth/idtokenclient';
 export {Claims, JWTAccess} from './auth/jwtaccess';
-export {JWT, JWTOptions, DefaultScopesKey} from './auth/jwtclient';
+export {JWT, JWTOptions, kDefaultScopes} from './auth/jwtclient';
 export {
   Certificates,
   CodeChallengeMethod,

--- a/test/test.jwt.ts
+++ b/test/test.jwt.ts
@@ -879,5 +879,16 @@ describe('jwt', () => {
       sandbox.assert.calledTwice(getExpirationTime);
       sandbox.assert.calledTwice(sign);
     });
+
+    it('returns no headers when no scopes or audiences are provided', async () => {
+      const jwt = new JWT({
+        email: 'foo@serviceaccount.com',
+        key: fs.readFileSync(PEM_PATH, 'utf8'),
+        scopes: [],
+        subject: 'bar@subjectaccount.com',
+      });
+      const headers = await jwt.getRequestHeaders();
+      assert.deepStrictEqual(headers, {});
+    });
   });
 });

--- a/test/test.jwt.ts
+++ b/test/test.jwt.ts
@@ -19,7 +19,7 @@ import * as jws from 'jws';
 import * as nock from 'nock';
 import * as sinon from 'sinon';
 
-import {GoogleAuth, JWT} from '../src';
+import {GoogleAuth, JWT, DefaultScopesKey} from '../src';
 import {CredentialRequest, JWTInput} from '../src/auth/credentials';
 import * as jwtaccess from '../src/auth/jwtaccess';
 
@@ -812,7 +812,7 @@ describe('jwt', () => {
       const jwt = new JWT({
         email: 'foo@serviceaccount.com',
         key: fs.readFileSync(PEM_PATH, 'utf8'),
-        defaultScopes: ['http://bar', 'http://foo'],
+        [DefaultScopesKey]: ['http://bar', 'http://foo'],
         subject: 'bar@subjectaccount.com',
       });
       jwt.credentials = {refresh_token: 'jwt-placeholder'};
@@ -829,7 +829,7 @@ describe('jwt', () => {
         email: 'foo@serviceaccount.com',
         key: keys.private,
         subject: 'ignored@subjectaccount.com',
-        defaultScopes: ['foo', 'bar'],
+        [DefaultScopesKey]: ['foo', 'bar'],
         additionalClaims: {target_audience: 'beepboop'},
       });
       jwt.credentials = {refresh_token: 'jwt-placeholder'};

--- a/test/test.jwt.ts
+++ b/test/test.jwt.ts
@@ -19,7 +19,7 @@ import * as jws from 'jws';
 import * as nock from 'nock';
 import * as sinon from 'sinon';
 
-import {GoogleAuth, JWT, DefaultScopesKey} from '../src';
+import {GoogleAuth, JWT, kDefaultScopes} from '../src';
 import {CredentialRequest, JWTInput} from '../src/auth/credentials';
 import * as jwtaccess from '../src/auth/jwtaccess';
 
@@ -812,7 +812,7 @@ describe('jwt', () => {
       const jwt = new JWT({
         email: 'foo@serviceaccount.com',
         key: fs.readFileSync(PEM_PATH, 'utf8'),
-        [DefaultScopesKey]: ['http://bar', 'http://foo'],
+        [kDefaultScopes]: ['http://bar', 'http://foo'],
         subject: 'bar@subjectaccount.com',
       });
       jwt.credentials = {refresh_token: 'jwt-placeholder'};
@@ -829,7 +829,7 @@ describe('jwt', () => {
         email: 'foo@serviceaccount.com',
         key: keys.private,
         subject: 'ignored@subjectaccount.com',
-        [DefaultScopesKey]: ['foo', 'bar'],
+        [kDefaultScopes]: ['foo', 'bar'],
         additionalClaims: {target_audience: 'beepboop'},
       });
       jwt.credentials = {refresh_token: 'jwt-placeholder'};

--- a/test/test.jwt.ts
+++ b/test/test.jwt.ts
@@ -19,7 +19,7 @@ import * as jws from 'jws';
 import * as nock from 'nock';
 import * as sinon from 'sinon';
 
-import {GoogleAuth, JWT, kDefaultScopes} from '../src';
+import {GoogleAuth, JWT} from '../src';
 import {CredentialRequest, JWTInput} from '../src/auth/credentials';
 import * as jwtaccess from '../src/auth/jwtaccess';
 
@@ -812,9 +812,9 @@ describe('jwt', () => {
       const jwt = new JWT({
         email: 'foo@serviceaccount.com',
         key: fs.readFileSync(PEM_PATH, 'utf8'),
-        [kDefaultScopes]: ['http://bar', 'http://foo'],
         subject: 'bar@subjectaccount.com',
       });
+      jwt.defaultScopes = ['http://bar', 'http://foo'];
       jwt.credentials = {refresh_token: 'jwt-placeholder'};
       await jwt.getRequestHeaders('https//beepboop.googleapis.com');
       sandbox.assert.calledOnce(JWTAccess);
@@ -829,9 +829,9 @@ describe('jwt', () => {
         email: 'foo@serviceaccount.com',
         key: keys.private,
         subject: 'ignored@subjectaccount.com',
-        [kDefaultScopes]: ['foo', 'bar'],
         additionalClaims: {target_audience: 'beepboop'},
       });
+      jwt.defaultScopes = ['foo', 'bar'];
       jwt.credentials = {refresh_token: 'jwt-placeholder'};
       const testUri = 'http:/example.com/my_test_service';
       const scope = createGTokenMock({id_token: 'abc123'});

--- a/test/test.jwt.ts
+++ b/test/test.jwt.ts
@@ -843,7 +843,8 @@ describe('jwt', () => {
     it('returns headers from cache, prior to their expiry time', async () => {
       const sign = sandbox.stub(jws, 'sign').returns('abc123');
       const getExpirationTime = sandbox
-        .stub(jwtaccess.JWTAccess, 'getExpirationTime')
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .stub(jwtaccess.JWTAccess as any, 'getExpirationTime')
         .returns(Date.now() / 1000 + 3600); // expire in an hour.
       const jwt = new JWT({
         email: 'foo@serviceaccount.com',
@@ -863,7 +864,8 @@ describe('jwt', () => {
     it('creates a new self-signed JWT, if headers are close to expiring', async () => {
       const sign = sandbox.stub(jws, 'sign').returns('abc123');
       const getExpirationTime = sandbox
-        .stub(jwtaccess.JWTAccess, 'getExpirationTime')
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .stub(jwtaccess.JWTAccess as any, 'getExpirationTime')
         .returns(Date.now() / 1000 + 5); // expire in 5 seconds.
       const jwt = new JWT({
         email: 'foo@serviceaccount.com',

--- a/test/test.transporters.ts
+++ b/test/test.transporters.ts
@@ -82,9 +82,7 @@ describe('transporters', () => {
       url: '',
     };
     let configuredOpts = transporter.configure(opts);
-    console.info(configuredOpts);
     configuredOpts = transporter.configure(opts);
-    console.info(configuredOpts);
     assert(
       /^gdcl\/[.-\w$]+ auth\/[.-\w$]+$/.test(
         configuredOpts.headers!['x-goog-api-client']


### PR DESCRIPTION
Start using self signed JWTs for client libraries when:

* A service account is being used 
* A scope has not been set by the user
* A target_audience has not been set by the user
* An api_endpoint has not been set by the user

This will require upstream work in the client libraries to begin populating `defaultScopes` rather than `scopes`.
