### PR TITLE
fix(deps): upgrade gtoken

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "fast-text-encoding": "^1.0.0",
     "gaxios": "^3.0.0",
     "gcp-metadata": "^4.1.0",
-    "gtoken": "^5.0.0",
+    "gtoken": "^5.0.4",
     "jws": "^4.0.0",
     "lru-cache": "^6.0.0"
   },


### PR DESCRIPTION
Addresses a potential prototype pollution leak: https://github.com/googleapis/node-gtoken/pull/337, https://github.com/digitalbazaar/forge/blob/588c41062d9a13f8dc91be3723b159c6cc434b15/CHANGELOG.md