### PR TITLE
feat: get AWS region from environment variable

### DIFF
--- a/src/auth/awsclient.ts
+++ b/src/auth/awsclient.ts
@@ -199,6 +199,9 @@ export class AwsClient extends BaseExternalAccountClient {
    * @return A promise that resolves with the current AWS region.
    */
   private async getAwsRegion(): Promise<string> {
+    if (process.env['AWS_REGION']) {
+      return process.env['AWS_REGION'];
+    }
     const opts: GaxiosOptions = {
       url: this.regionUrl,
       method: 'GET',

--- a/test/test.awsclient.ts
+++ b/test/test.awsclient.ts
@@ -504,16 +504,19 @@ describe('AwsClient', () => {
     let envAwsAccessKeyId: string | undefined;
     let envAwsSecretAccessKey: string | undefined;
     let envAwsSessionToken: string | undefined;
+    let envAwsRegion: string | undefined;
 
     beforeEach(() => {
       // Store external state.
       envAwsAccessKeyId = process.env.AWS_ACCESS_KEY_ID;
       envAwsSecretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
       envAwsSessionToken = process.env.AWS_SESSION_TOKEN;
+      envAwsAccessKeyId = process.env.AWS_REGION;
       // Reset environment variables.
       delete process.env.AWS_ACCESS_KEY_ID;
       delete process.env.AWS_SECRET_ACCESS_KEY;
       delete process.env.AWS_SESSION_TOKEN;
+      delete process.env.AWS_REGION;
     });
 
     afterEach(() => {
@@ -532,6 +535,11 @@ describe('AwsClient', () => {
         process.env.AWS_SESSION_TOKEN = envAwsSessionToken;
       } else {
         delete process.env.AWS_SESSION_TOKEN;
+      }
+      if (envAwsRegion) {
+        process.env.AWS_REGION = envAwsRegion;
+      } else {
+        delete process.env.AWS_REGION;
       }
     });
 
@@ -582,6 +590,17 @@ describe('AwsClient', () => {
           code: '500',
         });
         scope.done();
+      });
+
+      it('should resolve when AWS region is set as environment variable', async () => {
+        process.env.AWS_ACCESS_KEY_ID = accessKeyId;
+        process.env.AWS_SECRET_ACCESS_KEY = secretAccessKey;
+        process.env.AWS_REGION = awsRegion;
+
+        const client = new AwsClient(awsOptions);
+        const subjectToken = await client.retrieveSubjectToken();
+
+        assert.deepEqual(subjectToken, expectedSubjectTokenNoToken);
       });
     });
 


### PR DESCRIPTION
This gets the AWS region from the environment variable AWS_REGION as an alternative to invoking the AWS metadata service which is not available on all AWS products (such as Lambda)

- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-auth-library-nodejs/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary): there doesn't seem to be any documentation (yet?) about using AWS_* env vars

Fixes #1066 🦕
