### PR TITLE
use default AWS urls when not set in AwsClientOptions

### DIFF
--- a/src/auth/baseexternalclient.ts
+++ b/src/auth/baseexternalclient.ts
@@ -55,15 +55,37 @@ export const CLOUD_RESOURCE_MANAGER =
 
 /**
  * Base external account credentials json interface.
+ * https://cloud.google.com/iam/docs/reference/sts/rest/v1beta/TopLevel/token
  */
 export interface BaseExternalAccountClientOptions {
+  /**
+   * Required `external_account`
+   */
   type: string;
+  /**
+   * The full resource name of the identity provider. For example,
+   * `//iam.googleapis.com/projects/<project-number>/workloadIdentityPools/<pool-id>/providers/<provider-id>`.
+   */
   audience: string;
+  /**
+   * What kind of token is being exchanged for a google access token.
+   * `urn:ietf:params:oauth:token-type:accessToken` for OIDC based providers or
+   * `urn:ietf:params:aws:token-type:aws4_request` for AWS
+   */
   subject_token_type: string;
+  /**
+   * When specified, use this URl to get an accessToken to impersonate a service account.
+   * For example, `https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/<service-account-email>:generateAccessToken`
+   */
   service_account_impersonation_url?: string;
+  /**
+   * URL where the credentials can be exchanged for a Google OAuth 2.0 access token.
+   * For example, `https://sts.googleapis.com/v1beta/token`
+   */
   token_url: string;
-  token_info_url?: string;
+  /** Optional client-id for invoking `token_url` */
   client_id?: string;
+  /** Optional client-secret for invoking `token_url` */
   client_secret?: string;
   quota_project_id?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,11 @@ export {
   UserRefreshClient,
   UserRefreshClientOptions,
 } from './auth/refreshclient';
-export {AwsClient, AwsClientOptions} from './auth/awsclient';
+export {
+  AwsClient,
+  AwsClientOptions,
+  AwsClientCredentialSource,
+} from './auth/awsclient';
 export {
   IdentityPoolClient,
   IdentityPoolClientOptions,


### PR DESCRIPTION
- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-auth-library-nodejs/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea: see #1066 
- [X] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes #1066 🦕

This makes the URLs in the AwsClientOptions.credential_source optional. Most people would never need to supply different values, but this keeps that option available. This is convenient for users, but also makes it less awkward that you have to specify these URL's when using the AWS_* environment variables. When using environment variables, the URL's are never used which makes it awkward that you would have to specify them.

I also added jsdoc comments to all config options which might make it easier for people to configure the large number of options.

PS. I also removed `token_info_url` from `BaseExternalAccountClientOptions` as I couldn't find that it is used anywhere.
