### PR TITLE
build: only check engines on prod

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,11 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: node --version
-      - run: npm install --engine-strict
+      # The first installation step ensures that all of our production
+      # dependencies work on the given Node.js version, this helps us find
+      # dependencies that don't match our engines field:
+      - run: npm install --production --engine-strict
+      - run: npm install
       - run: npm test
       - name: coverage
         uses: codecov/codecov-action@v1

--- a/synth.metadata
+++ b/synth.metadata
@@ -3,15 +3,8 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/google-auth-library-nodejs.git",
-        "sha": "2004c42087bedfd2ff4b864e77065bfc3496ceca"
-      }
-    },
-    {
-      "git": {
-        "name": "synthtool",
-        "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "0c868d49b8e05bc1f299bc773df9eb4ef9ed96e9"
+        "remote": "git@github.com:googleapis/google-auth-library-nodejs.git",
+        "sha": "084da82a00d0fe3352b51f72a3c64468dfcf1eef"
       }
     }
   ],
@@ -64,7 +57,6 @@
     "CONTRIBUTING.md",
     "LICENSE",
     "api-extractor.json",
-    "renovate.json",
-    "samples/README.md"
+    "renovate.json"
   ]
 }

--- a/synth.metadata
+++ b/synth.metadata
@@ -60,3 +60,4 @@
     "renovate.json"
   ]
 }
+

--- a/synth.metadata
+++ b/synth.metadata
@@ -60,4 +60,3 @@
     "renovate.json"
   ]
 }
-


### PR DESCRIPTION
This performs the `--engine-strict` check as a separate step, installing on `--production` dependencies .