### PR TITLE
fix: update gcp-metadata to catch a json-bigint security fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ecdsa-sig-formatter": "^1.0.11",
     "fast-text-encoding": "^1.0.0",
     "gaxios": "^3.0.0",
-    "gcp-metadata": "^4.1.0",
+    "gcp-metadata": "^4.2.0",
     "gtoken": "^5.0.4",
     "jws": "^4.0.0",
     "lru-cache": "^6.0.0"


### PR DESCRIPTION
Fixes: https://github.com/googleapis/nodejs-pubsub/issues/1121

A pub/sub user reported a security vulnerability being pulled in through google-auth-library-nodejs -> gcp_metadata -> json_bigint. This just bumps the minimum gcp_metadata to pull that in.

