### PR TITLE
fix: call addSharedMetadataHeaders even when token has not expired

### DIFF
--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -786,7 +786,7 @@ export class OAuth2Client extends AuthClient {
       const headers = {
         Authorization: thisCreds.token_type + ' ' + thisCreds.access_token,
       };
-      return {headers};
+      return {headers: this.addSharedMetadataHeaders(headers)};
     }
 
     if (this.apiKey) {

--- a/test/test.refresh.ts
+++ b/test/test.refresh.ts
@@ -152,4 +152,22 @@ describe('refresh', () => {
     assert.strictEqual(headers['x-goog-user-project'], 'my-quota-project');
     req.done();
   });
+
+  it('getRequestHeaders should populate x-goog-user-project header if quota_project_id present and token has not expired', async () => {
+    const stream = fs.createReadStream(
+      './test/fixtures/config-with-quota/.config/gcloud/application_default_credentials.json'
+    );
+    const eagerRefreshThresholdMillis = 10;
+    const refresh = new UserRefreshClient({
+      eagerRefreshThresholdMillis,
+    });
+    await refresh.fromStream(stream);
+    refresh.credentials = {
+      access_token: 'woot',
+      refresh_token: 'jwt-placeholder',
+      expiry_date: new Date().getTime() + eagerRefreshThresholdMillis + 1000,
+    };
+    const headers = await refresh.getRequestHeaders();
+    assert.strictEqual(headers['x-goog-user-project'], 'my-quota-project');
+  });
 });


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-auth-library-nodejs/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #1114  🦕

---

```
npm test -- -g "getRequestHeaders should populate x-goog-user-project"
```
before
```
  refresh
    ✓ getRequestHeaders should populate x-goog-user-project header if quota_project_id present
    1) getRequestHeaders should populate x-goog-user-project header if quota_project_id present and token has not expired


  1 passing (43ms)
  1 failing

  1) refresh
       getRequestHeaders should populate x-goog-user-project header if quota_project_id present and token has not expired:
     AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+ actual - expected

+ undefined
- 'my-quota-project'

```
after
```
  refresh
    ✓ getRequestHeaders should populate x-goog-user-project header if quota_project_id present
    ✓ getRequestHeaders should populate x-goog-user-project header if quota_project_id present and token has not expired
```
