### PR TITLE
fix: expose missing external account client types/classes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,10 @@ export {
   ExternalAccountClient,
   ExternalAccountClientOptions,
 } from './auth/externalclient';
+export {
+  BaseExternalAccountClient,
+  BaseExternalAccountClientOptions,
+} from './auth/baseexternalclient';
 export {DefaultTransporter} from './transporters';
 
 const auth = new GoogleAuth();

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -41,5 +41,6 @@ describe('index', () => {
     assert(gal.ExternalAccountClient);
     assert(gal.IdentityPoolClient);
     assert(gal.AwsClient);
+    assert(gal.BaseExternalAccountClient);
   });
 });


### PR DESCRIPTION
Expose `BaseExternalAccountClient` and `BaseExternalAccountClientOptions`

The above base class and interface need to be exposed to unblock downstream libraries dependency on v7.

https://github.com/googleapis/nodejs-googleapis-common/pull/363
https://github.com/googleapis/google-api-nodejs-client/pull/2514
https://github.com/googleapis/nodejs-translate/pull/622
https://github.com/googleapis/gax-nodejs/pull/959