### PR TITLE
fix: update return type to be string vs. number

### DIFF
--- a/src/transporters.ts
+++ b/src/transporters.ts
@@ -141,11 +141,11 @@ export class DefaultTransporter {
         err.message = body.error.errors
           .map((err2: Error) => err2.message)
           .join('\n');
-        err.code = body.error.code;
+        err.code = body.error.code.toString();
         err.errors = body.error.errors;
       } else {
         err.message = body.error.message;
-        err.code = body.error.code || res.status;
+        err.code = body.error.code.toString() || res.status.toString();
       }
     } else if (res && res.status >= 400) {
       // Consider all 4xx and 5xx responses errors.

--- a/test/test.transporters.ts
+++ b/test/test.transporters.ts
@@ -100,7 +100,7 @@ describe('transporters', () => {
     transporter.request({url}, error => {
       scope.done();
       assert.strictEqual(error!.message, 'Error 1\nError 2');
-      assert.strictEqual((error as RequestError).code, 500);
+      assert.strictEqual((error as RequestError).code, '500');
       assert.strictEqual((error as RequestError).errors.length, 2);
       done();
     });


### PR DESCRIPTION
Fixes #1092 
`GaxiosError` returns [code as a string](https://github.com/googleapis/gaxios/blob/18a48fc298c8d0e707b7f6e5cd892cb7c239f1db/src/common.ts#L21), but this method in the auth library overwrites the `code` as a number. We're just updating it to return a string to be consistent.
