### PR TITLE
feat: Implement support for exposing refreshHandler callback to handle token refresh.

### DIFF
--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -810,7 +810,7 @@ export class OAuth2Client extends AuthClient {
       !this.refreshHandler
     ) {
       throw new Error(
-        'No access, refresh token or API key or refresh handler callback is set.'
+        'No access, refresh token, API key or refresh handler callback is set.'
       );
     }
 

--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -28,7 +28,6 @@ import {BodyResponseCallback} from '../transporters';
 import {AuthClient} from './authclient';
 import {CredentialRequest, Credentials} from './credentials';
 import {LoginTicket, TokenPayload} from './loginticket';
-import {getErrorFromOAuthErrorResponse} from './oauth2common';
 /**
  * The results from the `generateCodeVerifierAsync` method.  To learn more,
  * See the sample:

--- a/test/test.oauth2.ts
+++ b/test/test.oauth2.ts
@@ -1401,6 +1401,20 @@ describe('oauth2', () => {
       );
     });
 
+    it('should throw error is refreshHandler does not return token', async () => {
+      const expectedRefreshedAccessToken = {
+        access_token: '',
+        expiry_date: 123456789,
+      };
+      client.refreshHandlerCallback = async () => {
+        return expectedRefreshedAccessToken;
+      };
+      await assert.rejects(
+        client.refreshHandler(),
+        'There is no access token being returned.'
+      );
+    });
+
     it('should call refreshHandler and set credential if providing refresh handler callback', async () => {
       const expectedRefreshedAccessToken = {
         access_token: 'access_token',

--- a/test/test.oauth2.ts
+++ b/test/test.oauth2.ts
@@ -25,7 +25,6 @@ import * as sinon from 'sinon';
 
 import {CodeChallengeMethod, OAuth2Client} from '../src';
 import {LoginTicket} from '../src/auth/loginticket';
-import {AccessTokenResponse} from '../src/auth/oauth2client';
 
 nock.disableNetConnect();
 

--- a/test/test.oauth2.ts
+++ b/test/test.oauth2.ts
@@ -25,7 +25,7 @@ import * as sinon from 'sinon';
 
 import {CodeChallengeMethod, OAuth2Client} from '../src';
 import {LoginTicket} from '../src/auth/loginticket';
-import {DownscopedAccessTokenResponse} from '../src/auth/oauth2client';
+import {AccessTokenResponse} from '../src/auth/oauth2client';
 
 nock.disableNetConnect();
 
@@ -1157,26 +1157,26 @@ describe('oauth2', () => {
           .reply(code, {
             error: {code, message: 'Invalid Credentials'},
           });
-        const expectedDownscopedCred = {
+        const expectedRefreshedAccessToken = {
           access_token: 'access_token',
           expiry_date: 123456789,
         };
-        client.refreshHandler = async () => {
-          return expectedDownscopedCred;
+        client.refreshHandlerCallback = async () => {
+          return expectedRefreshedAccessToken;
         };
         client.setCredentials({
           access_token: 'initial-access-token',
           expiry_date: new Date().getTime() - 1000,
         });
-        await client.request({url: 'http://example.com'}, () => {
+        client.request({url: 'http://example.com'}, () => {
           scope.done();
           assert.strictEqual(
             client.credentials.access_token,
-            expectedDownscopedCred.access_token
+            expectedRefreshedAccessToken.access_token
           );
           assert.strictEqual(
             client.credentials.expiry_date,
-            expectedDownscopedCred.expiry_date
+            expectedRefreshedAccessToken.expiry_date
           );
         });
       });
@@ -1370,12 +1370,12 @@ describe('oauth2', () => {
     });
 
     it('should refresh request header when refreshHandler is available', async () => {
-      const expectedDownscopedCred = {
+      const expectedRefreshedAccessToken = {
         access_token: 'access_token',
         expiry_date: 123456789,
       };
-      client.refreshHandler = async () => {
-        return expectedDownscopedCred;
+      client.refreshHandlerCallback = async () => {
+        return expectedRefreshedAccessToken;
       };
       client.setCredentials({
         access_token: 'initial-access-token',
@@ -1402,41 +1402,41 @@ describe('oauth2', () => {
     });
 
     it('should call refreshHandler and set credential if providing refresh handler callback', async () => {
-      const expectedDownscopedCred = {
+      const expectedRefreshedAccessToken = {
         access_token: 'access_token',
         expiry_date: 123456789,
       };
-      client.refreshHandler = async () => {
-        return expectedDownscopedCred;
+      client.refreshHandlerCallback = async () => {
+        return expectedRefreshedAccessToken;
       };
-      const downscopedCred =
-        (await client.refreshHandler()) as DownscopedAccessTokenResponse;
+      const refreshedAccessToken =
+        (await client.refreshHandler()) as AccessTokenResponse;
       assert.strictEqual(
-        downscopedCred.access_token,
-        expectedDownscopedCred.access_token
+        refreshedAccessToken.access_token,
+        expectedRefreshedAccessToken.access_token
       );
       assert.strictEqual(
-        downscopedCred.expiry_date,
-        expectedDownscopedCred.expiry_date
+        refreshedAccessToken.expiry_date,
+        expectedRefreshedAccessToken.expiry_date
       );
     });
 
     it('should refresh credential when refreshHandler is available in getAccessToken()', async () => {
-      const expectedDownscopedCred = {
+      const expectedRefreshedAccessToken = {
         access_token: 'access_token',
         expiry_date: 123456789,
       };
-      client.refreshHandler = async () => {
-        return expectedDownscopedCred;
+      client.refreshHandlerCallback = async () => {
+        return expectedRefreshedAccessToken;
       };
       client.setCredentials({
         access_token: 'initial-access-token',
         expiry_date: new Date().getTime() - 1000,
       });
-      const downscopedCred = await client.getAccessToken();
+      const refreshedAccessToken = await client.getAccessToken();
       assert.strictEqual(
-        downscopedCred.token,
-        expectedDownscopedCred.access_token
+        refreshedAccessToken.token,
+        expectedRefreshedAccessToken.access_token
       );
     });
   });


### PR DESCRIPTION
Design Doc: [link](https://docs.google.com/document/d/1MJb9SH7cgGQYTUb6cShtMoOuaU3b05XtU4BVijGVok0/edit?resourcekey=0-K6R_URgisKyatWB6cXPK5g#heading=h.rjoi9m8cpb7k)
For this PR, developer has to provide a callback function returns access_token and expire_time both mandatory.
@bojeil-google @bcoe @lsirac Your feedback is highly appreciated!

There're 8 test cases:
getRequestHeader():
1. expired token, calling refreshHandler
2. token not expired, return authorized header with current token
3. no credentials in client, calling refreshHandler

request():
1. one with calling refreshHandler callback case
2. no credentials in client, calling refreshHandler

getAccessToken():
1. call refreshHandler when token expires and no refresh token
2. no credentials in client, calling refreshHandler

RefreshHandler returns no access token:
1. define refresh handler callback with empty access token, rejected when trying to refresh in getAccessToken()

Modify other error message and description in tests due to addition of refreshHandler logic.
Modify other test cases in request() to add another mock for 2nd successful request.

Note:
Since the logic of throwing error is in [refreshTokenNoCache](https://github.com/googleapis/google-auth-library-nodejs/blob/506bf9921d9a6101cd5977b241274b46604692d8/src/auth/oauth2client.ts#L682) I didn’t add "no refreshHandler callback related information" to the error message in the test [case](https://github.com/googleapis/google-auth-library-nodejs/blob/506bf9921d9a6101cd5977b241274b46604692d8/test/test.oauth2.ts#L1429)