### PR TITLE
meta: add nodejs-auth as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 
 # The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/yoshi-nodejs
+*     @googleapis/yoshi-nodejs @googleapis/nodejs-auth
 
 # The github automation team is the default owner for the auto-approve file.
 .github/auto-approve.yml @googleapis/github-automation

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -6,5 +6,6 @@
   "release_level": "ga",
   "language": "nodejs",
   "repo": "googleapis/google-auth-library-nodejs",
-  "distribution_name": "google-auth-library"
+  "distribution_name": "google-auth-library",
+  "codeowner_team": "@googleapis/nodejs-auth"
 }


### PR DESCRIPTION
Adds `nodejs-auth` team as a CODEOWNER.