### PR TITLE
feat: add GoogleAuth.sign() support to external account client

### DIFF
--- a/samples/scripts/externalclient-setup.js
+++ b/samples/scripts/externalclient-setup.js
@@ -29,7 +29,8 @@
 //    identity pools).
 // 2. Security Admin (needed to get and set IAM policies).
 // 3. Service Account Token Creator (needed to generate Google ID tokens and
-//    access tokens).
+//    access tokens). This is also needed to call the IAMCredentials signBlob
+//    API.
 //
 // The following APIs need to be enabled on the project:
 // 1. Identity and Access Management (IAM) API.

--- a/samples/test/externalclient.test.js
+++ b/samples/test/externalclient.test.js
@@ -262,7 +262,7 @@ describe('samples for external-account', () => {
       type: 'external_account',
       audience: AUDIENCE_OIDC,
       subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
-      token_url: 'https://sts.googleapis.com/v1beta/token',
+      token_url: 'https://sts.googleapis.com/v1/token',
       service_account_impersonation_url:
         'https://iamcredentials.googleapis.com/v1/projects/' +
         `-/serviceAccounts/${clientEmail}:generateAccessToken`,
@@ -285,6 +285,38 @@ describe('samples for external-account', () => {
     assert.match(output, /DNS Info:/);
   });
 
+  it('should sign the blobs with IAM credentials API', async () => {
+    // Create file-sourced configuration JSON file.
+    // The created OIDC token will be used as the subject token and will be
+    // retrieved from a file location.
+    const config = {
+      type: 'external_account',
+      audience: AUDIENCE_OIDC,
+      subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
+      token_url: 'https://sts.googleapis.com/v1/token',
+      service_account_impersonation_url:
+        'https://iamcredentials.googleapis.com/v1/projects/' +
+        `-/serviceAccounts/${clientEmail}:generateAccessToken`,
+      credential_source: {
+        file: oidcTokenFilePath,
+      },
+    };
+    await writeFile(oidcTokenFilePath, oidcToken);
+    await writeFile(configFilePath, JSON.stringify(config));
+
+    // Run sample script with GOOGLE_APPLICATION_CREDENTIALS envvar
+    // pointing to the temporarily created configuration file.
+    // This script will use signBlob to sign some data using
+    // service account impersonated workload identity pool credentials.
+    const output = await execAsync(`${process.execPath} signBlob`, {
+      env: {
+        ...process.env,
+        GOOGLE_APPLICATION_CREDENTIALS: configFilePath,
+      },
+    });
+    assert.ok(output.length > 0);
+  });
+
   it('should acquire ADC for url-sourced creds', async () => {
     // Create url-sourced configuration JSON file.
     // The created OIDC token will be used as the subject token and will be
@@ -293,7 +325,7 @@ describe('samples for external-account', () => {
       type: 'external_account',
       audience: AUDIENCE_OIDC,
       subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
-      token_url: 'https://sts.googleapis.com/v1beta/token',
+      token_url: 'https://sts.googleapis.com/v1/token',
       service_account_impersonation_url:
         'https://iamcredentials.googleapis.com/v1/projects/' +
         `-/serviceAccounts/${clientEmail}:generateAccessToken`,
@@ -358,7 +390,7 @@ describe('samples for external-account', () => {
       type: 'external_account',
       audience: AUDIENCE_AWS,
       subject_token_type: 'urn:ietf:params:aws:token-type:aws4_request',
-      token_url: 'https://sts.googleapis.com/v1beta/token',
+      token_url: 'https://sts.googleapis.com/v1/token',
       service_account_impersonation_url:
         'https://iamcredentials.googleapis.com/v1/projects/' +
         `-/serviceAccounts/${clientEmail}:generateAccessToken`,

--- a/src/auth/baseexternalclient.ts
+++ b/src/auth/baseexternalclient.ts
@@ -177,6 +177,19 @@ export abstract class BaseExternalAccountClient extends AuthClient {
     this.projectNumber = this.getProjectNumber(this.audience);
   }
 
+  /** The service account email to be impersonated, if available. */
+  getServiceAccountEmail(): string | null {
+    if (this.serviceAccountImpersonationUrl) {
+      // Parse email from URL. The formal looks as follows:
+      // https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/name@project-id.iam.gserviceaccount.com:generateAccessToken
+      const matches = this.serviceAccountImpersonationUrl.match(
+        /serviceAccounts\/([^:]+):generateAccessToken$/
+      );
+      return (matches && matches[1]) || null;
+    }
+    return null;
+  }
+
   /**
    * Provides a mechanism to inject GCP access tokens directly.
    * When the provided credential expires, a new credential, using the

--- a/src/auth/baseexternalclient.ts
+++ b/src/auth/baseexternalclient.ts
@@ -182,10 +182,9 @@ export abstract class BaseExternalAccountClient extends AuthClient {
     if (this.serviceAccountImpersonationUrl) {
       // Parse email from URL. The formal looks as follows:
       // https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/name@project-id.iam.gserviceaccount.com:generateAccessToken
-      const matches = this.serviceAccountImpersonationUrl.match(
-        /serviceAccounts\/([^:]+):generateAccessToken$/
-      );
-      return (matches && matches[1]) || null;
+      const re = /serviceAccounts\/(?<email>[^:]+):generateAccessToken$/;
+      const result = re.exec(this.serviceAccountImpersonationUrl);
+      return result?.groups?.email || null;
     }
     return null;
   }

--- a/test/externalclienthelper.ts
+++ b/test/externalclienthelper.ts
@@ -51,7 +51,7 @@ const poolId = 'POOL_ID';
 const providerId = 'PROVIDER_ID';
 const baseUrl = 'https://sts.googleapis.com';
 const path = '/v1/token';
-const saEmail = 'service-1234@service-name.iam.gserviceaccount.com';
+export const saEmail = 'service-1234@service-name.iam.gserviceaccount.com';
 const saBaseUrl = 'https://iamcredentials.googleapis.com';
 const saPath = `/v1/projects/-/serviceAccounts/${saEmail}:generateAccessToken`;
 

--- a/test/test.baseexternalclient.ts
+++ b/test/test.baseexternalclient.ts
@@ -22,6 +22,7 @@ import {StsSuccessfulResponse} from '../src/auth/stscredentials';
 import {
   EXPIRATION_TIME_OFFSET,
   BaseExternalAccountClient,
+  BaseExternalAccountClientOptions,
 } from '../src/auth/baseexternalclient';
 import {
   OAuthErrorResponse,
@@ -187,6 +188,47 @@ describe('BaseExternalAccountClient', () => {
 
         assert(client.projectNumber === null);
       });
+    });
+  });
+
+  describe('getServiceAccountEmail()', () => {
+    it('should return the service account email when impersonation is used', () => {
+      const saEmail = 'service-1234@service-name.iam.gserviceaccount.com';
+      const saBaseUrl = 'https://iamcredentials.googleapis.com';
+      const saPath = `/v1/projects/-/serviceAccounts/${saEmail}:generateAccessToken`;
+      const options: BaseExternalAccountClientOptions = Object.assign(
+        {},
+        externalAccountOptions
+      );
+      options.service_account_impersonation_url = `${saBaseUrl}${saPath}`;
+      const client = new TestExternalAccountClient(options);
+
+      assert.strictEqual(client.getServiceAccountEmail(), saEmail);
+    });
+
+    it('should return null when impersonation is not used', () => {
+      const options: BaseExternalAccountClientOptions = Object.assign(
+        {},
+        externalAccountOptions
+      );
+      delete options.service_account_impersonation_url;
+      const client = new TestExternalAccountClient(options);
+
+      assert(client.getServiceAccountEmail() === null);
+    });
+
+    it('should return null when impersonation url is malformed', () => {
+      const saBaseUrl = 'https://iamcredentials.googleapis.com';
+      // Malformed path (missing the service account email).
+      const saPath = '/v1/projects/-/serviceAccounts/:generateAccessToken';
+      const options: BaseExternalAccountClientOptions = Object.assign(
+        {},
+        externalAccountOptions
+      );
+      options.service_account_impersonation_url = `${saBaseUrl}${saPath}`;
+      const client = new TestExternalAccountClient(options);
+
+      assert(client.getServiceAccountEmail() === null);
     });
   });
 


### PR DESCRIPTION
External account credentials previously did not support signing blobs.
The implementation previously depended on service account keys or
the service account email in order to call IAMCredentials signBlob.

When service account impersonation is used with external account
credentials, we can get the impersonated service account email and
call the signBlob API with the generated access token, provided the
token has the `iam.serviceAccounts.signBlob` permission. This is
included in the "Service Account Token Creator" role.

Fixes https://github.com/googleapis/google-auth-library-nodejs/issues/1215