### PR TITLE
feat: Make full implementation on DownscopedClient.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,10 @@ export {
   BaseExternalAccountClient,
   BaseExternalAccountClientOptions,
 } from './auth/baseexternalclient';
+export {
+  CredentialAccessBoundary, 
+  DownscopedClient,
+} from './auth/downscopedclient';
 export {DefaultTransporter} from './transporters';
 
 const auth = new GoogleAuth();

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ export {
   BaseExternalAccountClientOptions,
 } from './auth/baseexternalclient';
 export {
-  CredentialAccessBoundary, 
+  CredentialAccessBoundary,
   DownscopedClient,
 } from './auth/downscopedclient';
 export {DefaultTransporter} from './transporters';

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -42,6 +42,7 @@ describe('index', () => {
     assert(gal.IdentityPoolClient);
     assert(gal.AwsClient);
     assert(gal.BaseExternalAccountClient);
+    assert(gal.DownscopedClient);
     assert(gal.Impersonated);
   });
 });


### PR DESCRIPTION
This full implementation for downscoped client is just to satisfy requirement of the abstract class AuthClient, this is neither urgent and nor a blocker in terms of functionality since they're not expected to be used by token brokers.

Three components are added:
1. Add quota_project_id as an optional parameter in constructor.
2. Implement and test getRequestHeaders() API.
3. Implement and test request() API.
These implementations are mostly copied from BaseExternalClient.