### PR TITLE
fix(security): explicitly update keypair dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "karma-remap-coverage": "^0.1.5",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^5.0.0",
-    "keypair": "^1.0.1",
+    "keypair": "^1.0.4",
     "linkinator": "^2.0.0",
     "mocha": "^8.0.0",
     "mv": "^2.1.1",


### PR DESCRIPTION
Updates `keypair` to resolve: https://securitylab.github.com/advisories/GHSL-2021-1012-keypair/.

Rather, it changes the minimum required version to be the latest fixed version.

I'm unsure whether the actual affected codepath is traversed that would result in surfacing this issue.
