### PR TITLE
chore: add api_shortname and library_type to repo metadata

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,5 +9,5 @@
   "distribution_name": "google-auth-library",
   "codeowner_team": "@googleapis/nodejs-auth",
   "api_shortname": "google-auth-library",
-  "library_type": ""
+  "library_type": "AUTH"
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -3,9 +3,11 @@
   "name_pretty": "Google Auth Library",
   "product_documentation": "https://cloud.google.com/docs/authentication/",
   "client_documentation": "https://cloud.google.com/nodejs/docs/reference/google-auth-library/latest",
-  "release_level": "ga",
+  "release_level": "stable",
   "language": "nodejs",
   "repo": "googleapis/google-auth-library-nodejs",
   "distribution_name": "google-auth-library",
-  "codeowner_team": "@googleapis/nodejs-auth"
+  "codeowner_team": "@googleapis/nodejs-auth",
+  "api_shortname": "google-auth-library",
+  "library_type": ""
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -8,6 +8,5 @@
   "repo": "googleapis/google-auth-library-nodejs",
   "distribution_name": "google-auth-library",
   "codeowner_team": "@googleapis/nodejs-auth",
-  "api_shortname": "google-auth-library",
   "library_type": "AUTH"
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # [Google Auth Library: Node.js Client](https://github.com/googleapis/google-auth-library-nodejs)
 
-[![release level](https://img.shields.io/badge/release%20level-general%20availability%20%28GA%29-brightgreen.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
+
 [![npm version](https://img.shields.io/npm/v/google-auth-library.svg)](https://www.npmjs.org/package/google-auth-library)
 [![codecov](https://img.shields.io/codecov/c/github/googleapis/google-auth-library-nodejs/main.svg?style=flat)](https://codecov.io/gh/googleapis/google-auth-library-nodejs)
 
@@ -888,12 +888,6 @@ _Legacy Node.js versions are supported as a best effort:_
 
 This library follows [Semantic Versioning](http://semver.org/).
 
-
-This library is considered to be **General Availability (GA)**. This means it
-is stable; the code surface will not change in backwards-incompatible ways
-unless absolutely necessary (e.g. because of critical security issues) or with
-an extensive deprecation period. Issues and requests against **GA** libraries
-are addressed with the highest priority.
 
 
 

--- a/README.md
+++ b/README.md
@@ -890,6 +890,11 @@ This library follows [Semantic Versioning](http://semver.org/).
 
 
 
+This library is considered to be **stable**. The code surface will not change in backwards-incompatible ways
+unless absolutely necessary (e.g. because of critical security issues) or with
+an extensive deprecation period. Issues and requests against **stable** libraries
+are addressed with the highest priority.
+
 
 
 


### PR DESCRIPTION
Update .repo-metadata.json as required by go/library-data-integrity 