### PR TITLE
feat: add api key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ npm install google-auth-library
 ## Ways to authenticate
 This library provides a variety of ways to authenticate to your Google services.
 - [Application Default Credentials](#choosing-the-correct-credential-type-automatically) - Use Application Default Credentials when you use a single identity for all users in your application. Especially useful for applications running on Google Cloud. Application Default Credentials also support workload identity federation to access Google Cloud resources from non-Google Cloud platforms.
+- [API key](#api-key) - An [API key](https://cloud.google.com/docs/authentication/api-keys) is a simple encrypted string that identifies an application without any principal. They are useful for accessing public data anonymously, and are used to associate API requests with your project for quota and billing.
 - [OAuth 2](#oauth2) - Use OAuth2 when you need to perform actions on behalf of the end user.
 - [JSON Web Tokens](#json-web-tokens) - Use JWT when you are using a single identity for all users. Especially useful for server->server or server->API communication.
 - [Google Compute](#compute) - Directly use a service account on Google Cloud Platform. Useful for server->server or server->API communication.
@@ -99,6 +100,35 @@ async function main() {
   const projectId = await auth.getProjectId();
   const url = `https://dns.googleapis.com/dns/v1/projects/${projectId}`;
   const res = await client.request({ url });
+  console.log(res.data);
+}
+
+main().catch(console.error);
+```
+
+## API key
+[API key](https://cloud.google.com/docs/authentication/api-keys) are useful for accessing public data anonymously, and are used to associate API requests with your project for quota and billing. You can follow the instructions on [this page](https://cloud.google.com/docs/authentication/api-keys) to create an API key.
+
+There are two methods to provide the API key: either provide it using the `apiKey` option to [`GoogleAuth`](https://github.com/googleapis/google-auth-library-nodejs/blob/main/src/auth/googleauth.ts#L154) constructor,
+or set the `GOOGLE_API_KEY` environment variable to the API key value. The following example demonstrates how to use API key with the Google Cloud Language API. 
+
+```js
+const {GoogleAuth} = require('google-auth-library');
+
+async function main() {
+  // There are two ways to provide API key. 
+  // One way is using the `apiKey` option as shown below
+  const auth = new GoogleAuth({
+    apiKey: 'fill in the API key'
+  });
+  // The second way is setting the `GOOGLE_API_KEY` environment variable
+  // to the API key value.
+  // const auth = new GoogleAuth();
+
+  const client = await auth.getClient();
+  const url = `https://language.googleapis.com/v1/documents:analyzeSentiment`;
+  const body = "{'document':{'type':'PLAIN_TEXT','content':'hello world'},'encodingType':'UTF8'}";
+  const res = await client.request({ 'url':url, 'method':'POST', 'body':body });
   console.log(res.data);
 }
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ npm install google-auth-library
 ## Ways to authenticate
 This library provides a variety of ways to authenticate to your Google services.
 - [Application Default Credentials](#choosing-the-correct-credential-type-automatically) - Use Application Default Credentials when you use a single identity for all users in your application. Especially useful for applications running on Google Cloud. Application Default Credentials also support workload identity federation to access Google Cloud resources from non-Google Cloud platforms.
+- [API key](#api-key) - Use API key for accessing public data anonymously.
 - [OAuth 2](#oauth2) - Use OAuth2 when you need to perform actions on behalf of the end user.
 - [JSON Web Tokens](#json-web-tokens) - Use JWT when you are using a single identity for all users. Especially useful for server->server or server->API communication.
 - [Google Compute](#compute) - Directly use a service account on Google Cloud Platform. Useful for server->server or server->API communication.
@@ -99,6 +100,35 @@ async function main() {
   const projectId = await auth.getProjectId();
   const url = `https://dns.googleapis.com/dns/v1/projects/${projectId}`;
   const res = await client.request({ url });
+  console.log(res.data);
+}
+
+main().catch(console.error);
+```
+
+## API key
+[API key](https://cloud.google.com/docs/authentication/api-keys) are useful for accessing public data anonymously, and are used to associate API requests with your project for quota and billing. You can follow the instructions on [this page](https://cloud.google.com/docs/authentication/api-keys) to create an API key.
+
+There are two methods to provide the API key: either provide it using the `apiKey` option to `GoogleAuth` constructor,
+or set the `GOOGLE_API_KEY` environment variable to the API key value. The following example demonstrates how to use API key with the Google Cloud Language API. 
+
+```js
+const {GoogleAuth} = require('google-auth-library');
+
+async function main() {
+  // There are two ways to provide API key. 
+  // One way is using the `apiKey` option as shown below
+  const auth = new GoogleAuth({
+    apiKey: 'fill in the API key'
+  });
+  // The second way is setting the `GOOGLE_API_KEY` environment variable
+  // to the API key value.
+  // const auth = new GoogleAuth();
+
+  const client = await auth.getClient();
+  const url = `https://language.googleapis.com/v1/documents:analyzeSentiment`;
+  const body = "{'document':{'type':'PLAIN_TEXT','content':'hello world'},'encodingType':'UTF8'}";
+  const res = await client.request({ 'url':url, 'method':'POST', 'body':body });
   console.log(res.data);
 }
 
@@ -842,6 +872,7 @@ Samples are in the [`samples/`](https://github.com/googleapis/google-auth-librar
 | Sample                      | Source Code                       | Try it |
 | --------------------------- | --------------------------------- | ------ |
 | Adc | [source code](https://github.com/googleapis/google-auth-library-nodejs/blob/main/samples/adc.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/google-auth-library-nodejs&page=editor&open_in_editor=samples/adc.js,samples/README.md) |
+| API Key | [source code](https://github.com/googleapis/google-auth-library-nodejs/blob/main/samples/api-key.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/google-auth-library-nodejs&page=editor&open_in_editor=samples/api-key.js,samples/README.md) |
 | Compute | [source code](https://github.com/googleapis/google-auth-library-nodejs/blob/main/samples/compute.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/google-auth-library-nodejs&page=editor&open_in_editor=samples/compute.js,samples/README.md) |
 | Credentials | [source code](https://github.com/googleapis/google-auth-library-nodejs/blob/main/samples/credentials.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/google-auth-library-nodejs&page=editor&open_in_editor=samples/credentials.js,samples/README.md) |
 | Downscopedclient | [source code](https://github.com/googleapis/google-auth-library-nodejs/blob/main/samples/downscopedclient.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/google-auth-library-nodejs&page=editor&open_in_editor=samples/downscopedclient.js,samples/README.md) |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ npm install google-auth-library
 ## Ways to authenticate
 This library provides a variety of ways to authenticate to your Google services.
 - [Application Default Credentials](#choosing-the-correct-credential-type-automatically) - Use Application Default Credentials when you use a single identity for all users in your application. Especially useful for applications running on Google Cloud. Application Default Credentials also support workload identity federation to access Google Cloud resources from non-Google Cloud platforms.
-- [API key](#api-key) - Use API key for accessing public data anonymously.
 - [OAuth 2](#oauth2) - Use OAuth2 when you need to perform actions on behalf of the end user.
 - [JSON Web Tokens](#json-web-tokens) - Use JWT when you are using a single identity for all users. Especially useful for server->server or server->API communication.
 - [Google Compute](#compute) - Directly use a service account on Google Cloud Platform. Useful for server->server or server->API communication.
@@ -100,35 +99,6 @@ async function main() {
   const projectId = await auth.getProjectId();
   const url = `https://dns.googleapis.com/dns/v1/projects/${projectId}`;
   const res = await client.request({ url });
-  console.log(res.data);
-}
-
-main().catch(console.error);
-```
-
-## API key
-[API key](https://cloud.google.com/docs/authentication/api-keys) are useful for accessing public data anonymously, and are used to associate API requests with your project for quota and billing. You can follow the instructions on [this page](https://cloud.google.com/docs/authentication/api-keys) to create an API key.
-
-There are two methods to provide the API key: either provide it using the `apiKey` option to `GoogleAuth` constructor,
-or set the `GOOGLE_API_KEY` environment variable to the API key value. The following example demonstrates how to use API key with the Google Cloud Language API. 
-
-```js
-const {GoogleAuth} = require('google-auth-library');
-
-async function main() {
-  // There are two ways to provide API key. 
-  // One way is using the `apiKey` option as shown below
-  const auth = new GoogleAuth({
-    apiKey: 'fill in the API key'
-  });
-  // The second way is setting the `GOOGLE_API_KEY` environment variable
-  // to the API key value.
-  // const auth = new GoogleAuth();
-
-  const client = await auth.getClient();
-  const url = `https://language.googleapis.com/v1/documents:analyzeSentiment`;
-  const body = "{'document':{'type':'PLAIN_TEXT','content':'hello world'},'encodingType':'UTF8'}";
-  const res = await client.request({ 'url':url, 'method':'POST', 'body':body });
   console.log(res.data);
 }
 
@@ -872,7 +842,7 @@ Samples are in the [`samples/`](https://github.com/googleapis/google-auth-librar
 | Sample                      | Source Code                       | Try it |
 | --------------------------- | --------------------------------- | ------ |
 | Adc | [source code](https://github.com/googleapis/google-auth-library-nodejs/blob/main/samples/adc.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/google-auth-library-nodejs&page=editor&open_in_editor=samples/adc.js,samples/README.md) |
-| API Key | [source code](https://github.com/googleapis/google-auth-library-nodejs/blob/main/samples/api-key.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/google-auth-library-nodejs&page=editor&open_in_editor=samples/api-key.js,samples/README.md) |
+| Api-key | [source code](https://github.com/googleapis/google-auth-library-nodejs/blob/main/samples/api-key.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/google-auth-library-nodejs&page=editor&open_in_editor=samples/api-key.js,samples/README.md) |
 | Compute | [source code](https://github.com/googleapis/google-auth-library-nodejs/blob/main/samples/compute.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/google-auth-library-nodejs&page=editor&open_in_editor=samples/compute.js,samples/README.md) |
 | Credentials | [source code](https://github.com/googleapis/google-auth-library-nodejs/blob/main/samples/credentials.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/google-auth-library-nodejs&page=editor&open_in_editor=samples/credentials.js,samples/README.md) |
 | Downscopedclient | [source code](https://github.com/googleapis/google-auth-library-nodejs/blob/main/samples/downscopedclient.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/google-auth-library-nodejs&page=editor&open_in_editor=samples/downscopedclient.js,samples/README.md) |

--- a/samples/README.md
+++ b/samples/README.md
@@ -13,6 +13,7 @@ This is Google's officially supported [node.js](http://nodejs.org/) client libra
 * [Before you begin](#before-you-begin)
 * [Samples](#samples)
   * [Adc](#adc)
+  * [Api-key](#api-key)
   * [Compute](#compute)
   * [Credentials](#credentials)
   * [Downscopedclient](#downscopedclient)
@@ -53,6 +54,23 @@ __Usage:__
 
 
 `node samples/adc.js`
+
+
+-----
+
+
+
+
+### Api-key
+
+View the [source code](https://github.com/googleapis/google-auth-library-nodejs/blob/main/samples/api-key.js).
+
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/google-auth-library-nodejs&page=editor&open_in_editor=samples/api-key.js,samples/README.md)
+
+__Usage:__
+
+
+`node samples/api-key.js`
 
 
 -----

--- a/samples/api-key.js
+++ b/samples/api-key.js
@@ -1,0 +1,43 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Import the GoogleAuth library, and create a new GoogleAuth client.
+ */
+const {GoogleAuth} = require('google-auth-library');
+
+/**
+ * Acquire a client, and make a request to an API that's enabled by default.
+ */
+async function main() {
+  // There are two ways to provide API key.
+  // One way is using the `apiKey` option as shown below
+  const auth = new GoogleAuth({
+    apiKey: 'fill in the API key',
+  });
+  // The second way is setting the `GOOGLE_API_KEY` environment variable
+  // to the API key value.
+  // const auth = new GoogleAuth();
+
+  const client = await auth.getClient();
+  const url = 'https://language.googleapis.com/v1/documents:analyzeSentiment';
+  const body =
+    "{'document':{'type':'PLAIN_TEXT','content':'hello world'},'encodingType':'UTF8'}";
+  const res = await client.request({url: url, method: 'POST', body: body});
+  console.log(res.data);
+}
+
+main().catch(console.error);

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -300,14 +300,8 @@ export class GoogleAuth {
     if (this.apiKey) {
       credential = this.fromAPIKey(this.apiKey);
       this.cachedCredential = credential;
-
-      try {
-        projectId = await this.getProjectId();
-        return {credential, projectId};
-      } catch (error) {
-        projectId = null;
-        return {credential, projectId};
-      }
+      projectId = await this.getProjectId();
+      return {credential, projectId};
     }
 
     // Check for the existence of a local environment variable pointing to the

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -300,8 +300,14 @@ export class GoogleAuth {
     if (this.apiKey) {
       credential = this.fromAPIKey(this.apiKey);
       this.cachedCredential = credential;
-      projectId = await this.getProjectId();
-      return {credential, projectId};
+      // Project ID is not needed when using API key, so we just return it on a best effort basis.
+      try {
+        projectId = await this.getProjectId();
+        return {credential, projectId};
+      } catch (error) {
+        projectId = null;
+        return {credential, projectId};
+      }
     }
 
     // Check for the existence of a local environment variable pointing to the

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -1068,6 +1068,34 @@ describe('googleauth', () => {
       assert.strictEqual(undefined, client.scope);
     });
 
+    it('getApplicationDefault should use API key if provided via env var', async () => {
+      mockEnvVar('GOOGLE_API_KEY', API_KEY);
+      mockEnvVar('GCLOUD_PROJECT', STUB_PROJECT);
+      const auth = new GoogleAuth();
+      const res = await auth.getApplicationDefault();
+      const headers = await res.credential.getRequestHeaders();
+      assert.strictEqual(headers['X-Goog-Api-Key'], API_KEY);
+      assert.strictEqual(res.projectId, STUB_PROJECT);
+    });
+
+    it('getApplicationDefault should use API key if provided via options', async () => {
+      const auth = new GoogleAuth({apiKey: API_KEY});
+      const res = await auth.getApplicationDefault();
+      const headers = await res.credential.getRequestHeaders();
+      assert.strictEqual(headers['X-Goog-Api-Key'], API_KEY);
+      assert.strictEqual(res.projectId, null);
+    });
+
+    it('getApplicationDefault should throw error if both GOOGLE_API_KEY and GOOGLE_APPLICATION_CREDENTIALS are provided', async () => {
+      mockEnvVar('GOOGLE_API_KEY', API_KEY);
+      mockEnvVar('GOOGLE_APPLICATION_CREDENTIALS', '/path/to/adc/json');
+      const auth = new GoogleAuth();
+      await assert.rejects(
+        auth.getApplicationDefault(),
+        /GOOGLE_API_KEY and GOOGLE_APPLICATION_CREDENTIALS environment variables are mutually exclusive/
+      );
+    });
+
     it('_checkIsGCE should set the _isGCE flag when running on GCE', async () => {
       assert.notStrictEqual(true, auth.isGCE);
       const scope = nockIsGCE();


### PR DESCRIPTION
Add API key support. There are two ways to provide the API key, either by setting `GOOGLE_API_KEY` environment variable, or setting `apiKey` option in `GoogleAuth` constructor. `GOOGLE_API_KEY` and `GOOGLE_APPLICATION_CREDENTIALS` are mutually exclusive so providing both will cause an exception.

The code has been tested with the sample in this PR.
