### PR TITLE
feat: Export `AuthClient`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 import {GoogleAuth} from './auth/googleauth';
 
+export {AuthClient} from './auth/authclient';
 export {Compute, ComputeOptions} from './auth/computeclient';
 export {
   CredentialBody,


### PR DESCRIPTION
Makes it more convenient to use types that extend `AuthClient` (such as `BaseExternalAccountClient`, `DownscopedClient`, and `OAuth2Client`)