### PR TITLE
fix: Rename `auth` to `authClient` & Use Generics for `AuthClient`

### DIFF
--- a/samples/downscopedclient.js
+++ b/samples/downscopedclient.js
@@ -64,10 +64,10 @@ async function main() {
   const cabClient = new DownscopedClient(client, cab);
 
   // OAuth 2.0 Client
-  const oauth2Client = new OAuth2Client();
+  const authClient = new OAuth2Client();
   // Define a refreshHandler that will be used to refresh the downscoped token
   // when it expires.
-  oauth2Client.refreshHandler = async () => {
+  authClient.refreshHandler = async () => {
     const refreshedAccessToken = await cabClient.getAccessToken();
     return {
       access_token: refreshedAccessToken.token,
@@ -77,7 +77,7 @@ async function main() {
 
   const storageOptions = {
     projectId,
-    authClient: new GoogleAuth({auth: oauth2Client}),
+    authClient: new GoogleAuth({authClient}),
   };
 
   const storage = new Storage(storageOptions);

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -71,11 +71,11 @@ export interface ADCResponse {
   projectId: string | null;
 }
 
-export interface GoogleAuthOptions {
+export interface GoogleAuthOptions<T extends AuthClient = JSONClient> {
   /**
    * An `AuthClient` to use
    */
-  authClient?: AuthClient;
+  authClient?: T;
   /**
    * Path to a .json, .pem, or .p12 key file
    */
@@ -115,7 +115,7 @@ export interface GoogleAuthOptions {
 export const CLOUD_SDK_CLIENT_ID =
   '764086051850-6qr4p6gpi6hn506pt8ejuq83di341hur.apps.googleusercontent.com';
 
-export class GoogleAuth {
+export class GoogleAuth<T extends AuthClient = JSONClient> {
   transporter?: Transporter;
 
   /**
@@ -139,8 +139,7 @@ export class GoogleAuth {
   // To save the contents of the JSON credential file
   jsonContent: JWTInput | ExternalAccountClientOptions | null = null;
 
-  cachedCredential: JSONClient | Impersonated | Compute | AuthClient | null =
-    null;
+  cachedCredential: JSONClient | Impersonated | Compute | T | null = null;
 
   /**
    * Scopes populated by the client library by default. We differentiate between
@@ -156,7 +155,7 @@ export class GoogleAuth {
    */
   static DefaultTransporter = DefaultTransporter;
 
-  constructor(opts?: GoogleAuthOptions) {
+  constructor(opts?: GoogleAuthOptions<T>) {
     opts = opts || {};
 
     this._cachedProjectId = opts.projectId || null;

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -75,7 +75,7 @@ export interface GoogleAuthOptions {
   /**
    * An `AuthClient` to use
    */
-  auth?: AuthClient;
+  authClient?: AuthClient;
   /**
    * Path to a .json, .pem, or .p12 key file
    */
@@ -160,7 +160,7 @@ export class GoogleAuth {
     opts = opts || {};
 
     this._cachedProjectId = opts.projectId || null;
-    this.cachedCredential = opts.auth || null;
+    this.cachedCredential = opts.authClient || null;
     this.keyFilename = opts.keyFilename || opts.keyFile;
     this.scopes = opts.scopes;
     this.jsonContent = opts.credentials || null;

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -305,9 +305,7 @@ describe('googleauth', () => {
 
       const authClient = new MyAuthClient();
 
-      const auth = new GoogleAuth({
-        auth: authClient,
-      });
+      const auth = new GoogleAuth({authClient});
 
       assert.equal(auth.cachedCredential, authClient);
       assert.equal(await auth.getClient(), authClient);


### PR DESCRIPTION
Reduces type conflicts for downstream consumers.

NOTE: https://github.com/googleapis/nodejs-common/blob/6d1e19edc0765b4d5cc7a37ccc2fcb0e441e0815/src/service.ts#L65-L73 will need to be updated immediately after this change (as `GoogeAuth` != `AuthClient`)