### PR TITLE
chore(deps): Update `gtoken`'s minimum version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "fast-text-encoding": "^1.0.0",
     "gaxios": "^4.0.0",
     "gcp-metadata": "^4.2.0",
-    "gtoken": "^5.0.4",
+    "gtoken": "^5.3.2",
     "jws": "^4.0.0",
     "lru-cache": "^6.0.0"
   },


### PR DESCRIPTION
Fixes #1384 🦕