### PR TITLE
refactor!: remove deprecated DeprecatedGetClientOptions

### DIFF
--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -59,9 +59,6 @@ export interface CredentialCallback {
   (err: Error | null, result?: JSONClient): void;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface DeprecatedGetClientOptions {}
-
 export interface ADCCallback {
   (err: Error | null, credential?: AuthClient, projectId?: string | null): void;
 }
@@ -790,12 +787,7 @@ export class GoogleAuth<T extends AuthClient = JSONClient> {
    * Automatically obtain a client based on the provided configuration.  If no
    * options were passed, use Application Default Credentials.
    */
-  async getClient(options?: DeprecatedGetClientOptions) {
-    if (options) {
-      throw new Error(
-        'Passing options to getClient is forbidden in v5.0.0. Use new GoogleAuth(opts) instead.'
-      );
-    }
+  async getClient() {
     if (!this.cachedCredential) {
       if (this.jsonContent) {
         this._cacheClientFromJSON(this.jsonContent, this.clientOptions);

--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -709,7 +709,6 @@ export class OAuth2Client extends AuthClient {
   /**
    * Retrieves the access token using refresh token
    *
-   * @deprecated use getRequestHeaders instead.
    * @param callback callback
    */
   refreshAccessToken(): Promise<RefreshAccessTokenResponse>;

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -1496,14 +1496,6 @@ describe('googleauth', () => {
       );
     });
 
-    it('should throw if options are passed to getClient()', async () => {
-      const auth = new GoogleAuth();
-      await assert.rejects(
-        auth.getClient({hello: 'world'}),
-        /Passing options to getClient is forbidden in v5.0.0/
-      );
-    });
-
     it('getRequestHeaders populates x-goog-user-project with quota_project if present', async () => {
       const tokenReq = mockApplicationDefaultCredentials(
         './test/fixtures/config-with-quota'

--- a/test/test.oauth2.ts
+++ b/test/test.oauth2.ts
@@ -900,14 +900,6 @@ describe('oauth2', () => {
       });
     });
 
-    it('should not emit warning on refreshAccessToken', async () => {
-      let warned = false;
-      sandbox.stub(process, 'emitWarning').callsFake(() => (warned = true));
-      client.refreshAccessToken(() => {
-        assert.strictEqual(warned, false);
-      });
-    });
-
     it('should return error in callback on refreshAccessToken', done => {
       client.refreshAccessToken((err, result) => {
         assert.strictEqual(err!.message, 'No refresh token is set.');


### PR DESCRIPTION
- removed `options` from `GoogleAuth#getClient`
- removed dangling `@deprecated` from `OAuth2Client#refreshAccessToken`