### PR TITLE
fix: Fixing Implementation of GoogleAuth.sign() for external account credentials

### DIFF
--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -756,11 +756,11 @@ export class GoogleAuth<T extends AuthClient = JSONClient> {
   private async getCredentialsAsync(): Promise<CredentialBody> {
     const client = await this.getClient();
 
-    if (
-      client instanceof BaseExternalAccountClient &&
-      client.getServiceAccountEmail()
-    ) {
-      return {client_email: client.getServiceAccountEmail() as string};
+    if (client instanceof BaseExternalAccountClient) {
+      const serviceAccountEmail = client.getServiceAccountEmail();
+      if (serviceAccountEmail) {
+        return {client_email: serviceAccountEmail};
+      }
     }
 
     if (this.jsonContent) {

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -731,8 +731,8 @@ export class GoogleAuth<T extends AuthClient = JSONClient> {
    * The callback function handles a credential object that contains the
    * client_email and private_key (if exists).
    * getCredentials first checks if the client is using an external account and
-   * uses the service account email in place of client_email
-   * if that doesn't exist, it checks for these values from the user JSON.
+   * uses the service account email in place of client_email.
+   * If that doesn't exist, it checks for these values from the user JSON.
    * If the user JSON doesn't exist, and the environment is on GCE, it gets the
    * client_email from the cloud metadata server.
    * @param callback Callback that handles the credential object that contains

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -730,8 +730,10 @@ export class GoogleAuth<T extends AuthClient = JSONClient> {
   /**
    * The callback function handles a credential object that contains the
    * client_email and private_key (if exists).
-   * getCredentials checks for these values from the user JSON at first.
-   * If it doesn't exist, and the environment is on GCE, it gets the
+   * getCredentials first checks if the client is using an external account and
+   * uses the service account email in place of client_email
+   * if that doesn't exist, it checks for these values from the user JSON.
+   * If the user JSON doesn't exist, and the environment is on GCE, it gets the
    * client_email from the cloud metadata server.
    * @param callback Callback that handles the credential object that contains
    * a client_email and optional private key, or the error.
@@ -752,7 +754,14 @@ export class GoogleAuth<T extends AuthClient = JSONClient> {
   }
 
   private async getCredentialsAsync(): Promise<CredentialBody> {
-    await this.getClient();
+    const client = await this.getClient();
+
+    if (
+      client instanceof BaseExternalAccountClient &&
+      client.getServiceAccountEmail()
+    ) {
+      return {client_email: client.getServiceAccountEmail() as string};
+    }
 
     if (this.jsonContent) {
       const credential: CredentialBody = {
@@ -882,23 +891,6 @@ export class GoogleAuth<T extends AuthClient = JSONClient> {
     if (client instanceof JWT && client.key) {
       const sign = await crypto.sign(client.key, data);
       return sign;
-    }
-
-    // signBlob requires a service account email and the underlying
-    // access token to have iam.serviceAccounts.signBlob permission
-    // on the specified resource name.
-    // The "Service Account Token Creator" role should cover this.
-    // As a result external account credentials can support this
-    // operation when service account impersonation is enabled.
-    if (
-      client instanceof BaseExternalAccountClient &&
-      client.getServiceAccountEmail()
-    ) {
-      return this.signBlob(
-        crypto,
-        client.getServiceAccountEmail() as string,
-        data
-      );
     }
 
     const projectId = await this.getProjectId();

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -2239,7 +2239,7 @@ describe('googleauth', () => {
 
         it('should use IAMCredentials endpoint when impersonation is used', async () => {
           const scopes = mockGetAccessTokenAndProjectId(
-            false,
+            true,
             ['https://www.googleapis.com/auth/cloud-platform'],
             true
           );
@@ -2339,6 +2339,18 @@ describe('googleauth', () => {
 
         assert.deepStrictEqual(res.data, data);
         scopes.forEach(s => s.done());
+      });
+
+      it('getCredentials() should return the service account email for external accounts', async () => {
+        // Set up a mock to return path to a valid credentials file.
+        const email = saEmail;
+        const configWithImpersonation = createExternalAccountJSON();
+        configWithImpersonation.service_account_impersonation_url =
+          getServiceAccountImpersonationUrl();
+        const auth = new GoogleAuth({credentials: configWithImpersonation});
+        const body = await auth.getCredentials();
+        assert.notStrictEqual(null, body);
+        assert.strictEqual(email, body.client_email);
       });
     });
   });

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -2341,16 +2341,18 @@ describe('googleauth', () => {
         scopes.forEach(s => s.done());
       });
 
-      it('getCredentials() should return the service account email for external accounts', async () => {
-        // Set up a mock to return path to a valid credentials file.
-        const email = saEmail;
-        const configWithImpersonation = createExternalAccountJSON();
-        configWithImpersonation.service_account_impersonation_url =
-          getServiceAccountImpersonationUrl();
-        const auth = new GoogleAuth({credentials: configWithImpersonation});
-        const body = await auth.getCredentials();
-        assert.notStrictEqual(null, body);
-        assert.strictEqual(email, body.client_email);
+      describe('getCredentials()', () => {
+        it('getCredentials() should return the service account email for external accounts', async () => {
+          // Set up a mock to return path to a valid credentials file.
+          const email = saEmail;
+          const configWithImpersonation = createExternalAccountJSON();
+          configWithImpersonation.service_account_impersonation_url =
+            getServiceAccountImpersonationUrl();
+          const auth = new GoogleAuth({credentials: configWithImpersonation});
+          const body = await auth.getCredentials();
+          assert.notStrictEqual(null, body);
+          assert.strictEqual(email, body.client_email);
+        });
       });
     });
   });


### PR DESCRIPTION
Currently, creating signed storage URLs does not work for external account credentials because the storage library expects client_email to be returned from GoogleAuth.getCredentials(). Changing the logic so the same client email that is used to the sign the blob (extracted from the Service Account Impersonation URL) is returned from the getCredentials() call.

Fixes #1239  🦕
