### PR TITLE
feat!: Adding Pluggable Auth Support to ADC

### DIFF
--- a/src/auth/baseexternalclient.ts
+++ b/src/auth/baseexternalclient.ts
@@ -128,7 +128,7 @@ export abstract class BaseExternalAccountClient extends AuthClient {
   public scopes?: string | string[];
   private cachedAccessToken: CredentialsWithResponse | null;
   protected readonly audience: string;
-  private readonly subjectTokenType: string;
+  protected readonly subjectTokenType: string;
   private readonly serviceAccountImpersonationUrl?: string;
   private readonly stsCredential: sts.StsCredentials;
   private readonly clientAuth?: ClientAuthentication;

--- a/src/auth/executableresponse.ts
+++ b/src/auth/executableresponse.ts
@@ -1,0 +1,166 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const SAML_SUBJECT_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:saml2';
+const OIDC_SUBJECT_TOKEN_TYPE1 = 'urn:ietf:params:oauth:token-type:id_token';
+const OIDC_SUBJECT_TOKEN_TYPE2 = 'urn:ietf:params:oauth:token-type:jwt';
+
+/**
+ * Interface defining JSON format of response from 3rd party executable run by
+ * pluggable auth client.
+ */
+export interface ExecutableResponseJson {
+  /**
+   * Version of the response, only version 1 currently supported.
+   * Always required.
+   */
+  version: number;
+  /**
+   * Whether the executable ran successfully. Always required.
+   */
+  success: boolean;
+  /**
+   * Epoch time for expiration of the token in seconds, required for successful
+   * responses.
+   */
+  expiration_time?: number;
+  /**
+   * Type of subject token in the response, currently supported values are:
+   * urn:ietf:params:oauth:token-type:saml2
+   * urn:ietf:params:oauth:token-type:id_token
+   * urn:ietf:params:oauth:token-type:jwt
+   */
+  token_type?: string;
+  /**
+   * Error code from executable, required when unsuccessful.
+   */
+  code?: string;
+  /**
+   * Error message from executable, required when unsuccessful.
+   */
+  message?: string;
+  /**
+   * ID token to be used as a subject token when token_type is id_token or jwt.
+   */
+  id_token?: string;
+  /**
+   * Response to be used as a subject token when token_type is saml2.
+   */
+  saml_response?: string;
+}
+
+/**
+ * Class defining a response from a 3rd party executable run by the pluggable
+ * auth client.
+ */
+export class ExecutableResponse {
+  readonly version: number;
+  readonly success: boolean;
+  readonly expirationTime?: number;
+  readonly tokenType?: string;
+  readonly errorCode?: string;
+  readonly errorMessage?: string;
+  readonly subjectToken?: string;
+
+  /**
+   * Instantiates an ExecutableResponse instance using the provided JSON object
+   * from the output of the executable.
+   * @param responseJson Response from a 3rd party executable, loaded from a
+   * run of the executable or a cached output file.
+   */
+  constructor(responseJson: ExecutableResponseJson) {
+    // Check that always required fields exist in the json response.
+    if (!responseJson.version) {
+      throw Error("Executable response must contain a 'version' field.");
+    }
+    if (responseJson.success === undefined) {
+      throw Error("Executable response must contain a 'success' field.");
+    }
+
+    this.version = responseJson.version;
+    this.success = responseJson.success;
+
+    // Check that fields required when response is successful exist.
+    if (this.success) {
+      if (!responseJson.expiration_time) {
+        throw Error(
+          "Executable response must contain an 'expiration_time' field when successful."
+        );
+      }
+      if (!responseJson.token_type) {
+        throw Error(
+          "Executable response must contain a 'token_type' field when successful."
+        );
+      }
+      this.expirationTime = responseJson.expiration_time;
+      this.tokenType = responseJson.token_type;
+
+      // Check that type specific fields exist based on token_type provided and
+      // set subjectToken.
+      if (this.tokenType === SAML_SUBJECT_TOKEN_TYPE) {
+        if (!responseJson.saml_response) {
+          throw Error(
+            `Executable response must contain a 'saml_response' field when token_type=${SAML_SUBJECT_TOKEN_TYPE}.`
+          );
+        }
+        this.subjectToken = responseJson.saml_response;
+      } else if (
+        this.tokenType === OIDC_SUBJECT_TOKEN_TYPE1 ||
+        this.tokenType === OIDC_SUBJECT_TOKEN_TYPE2
+      ) {
+        if (!responseJson.id_token) {
+          throw Error(
+            "Executable response must contain a 'id_token' field when " +
+              `token_type=${OIDC_SUBJECT_TOKEN_TYPE1} or ${OIDC_SUBJECT_TOKEN_TYPE2}.`
+          );
+        }
+        this.subjectToken = responseJson.id_token;
+      } else {
+        throw Error(
+          "Executable response must contain a 'token_type' field when successful " +
+            `and it must be one of ${OIDC_SUBJECT_TOKEN_TYPE1}, ${OIDC_SUBJECT_TOKEN_TYPE2}, or ${SAML_SUBJECT_TOKEN_TYPE}.`
+        );
+      }
+    } else {
+      // Check that fields required for unsuccessful response exist.
+      if (!responseJson.code || !responseJson.message) {
+        throw Error(
+          "Executable response must contain a 'code' and 'message' field when unsuccessful."
+        );
+      }
+      this.errorCode = responseJson.code;
+      this.errorMessage = responseJson.message;
+    }
+  }
+
+  /**
+   * @return a boolean representing if the response has a valid token. Returns
+   * true when the response was successful and the token is not expired.
+   */
+  isValid(): boolean {
+    return !this.isExpired() && this.success;
+  }
+
+  /**
+   * @return a boolean representing if the response is expired. Returns true if
+   * the expiration_time field was not provided or if the provided time has
+   * passed.
+   */
+  isExpired(): boolean {
+    return (
+      !this.expirationTime ||
+      this.expirationTime < Math.round(Date.now() / 1000)
+    );
+  }
+}

--- a/src/auth/executableresponse.ts
+++ b/src/auth/executableresponse.ts
@@ -105,7 +105,7 @@ export class ExecutableResponse {
       this.expirationTime = responseJson.expiration_time;
       this.tokenType = responseJson.token_type;
 
-      // Validate that token type and subject token value.
+      // Validate token type and subject token value.
       if (this.tokenType === SAML_SUBJECT_TOKEN_TYPE) {
         if (!responseJson.saml_response) {
           throw Error(

--- a/src/auth/executableresponse.ts
+++ b/src/auth/executableresponse.ts
@@ -17,8 +17,8 @@ const OIDC_SUBJECT_TOKEN_TYPE1 = 'urn:ietf:params:oauth:token-type:id_token';
 const OIDC_SUBJECT_TOKEN_TYPE2 = 'urn:ietf:params:oauth:token-type:jwt';
 
 /**
- * Interface defining JSON format of response from 3rd party executable used by
- * pluggable auth client.
+ * Interface defining the JSON formatted response of a 3rd party executable
+ * used by the pluggable auth client.
  */
 export interface ExecutableResponseJson {
   /**

--- a/src/auth/executableresponse.ts
+++ b/src/auth/executableresponse.ts
@@ -105,7 +105,19 @@ export class ExecutableResponse {
       this.expirationTime = responseJson.expiration_time;
       this.tokenType = responseJson.token_type;
 
-      // Validate token type and subject token value.
+      // Validate token type field.
+      if (
+        this.tokenType !== SAML_SUBJECT_TOKEN_TYPE &&
+        this.tokenType !== OIDC_SUBJECT_TOKEN_TYPE1 &&
+        this.tokenType !== OIDC_SUBJECT_TOKEN_TYPE2
+      ) {
+        throw new Error(
+          "Executable response must contain a 'token_type' field when successful " +
+            `and it must be one of ${OIDC_SUBJECT_TOKEN_TYPE1}, ${OIDC_SUBJECT_TOKEN_TYPE2}, or ${SAML_SUBJECT_TOKEN_TYPE}.`
+        );
+      }
+
+      // Validate subject token.
       if (this.tokenType === SAML_SUBJECT_TOKEN_TYPE) {
         if (!responseJson.saml_response) {
           throw Error(
@@ -124,11 +136,6 @@ export class ExecutableResponse {
           );
         }
         this.subjectToken = responseJson.id_token;
-      } else {
-        throw Error(
-          "Executable response must contain a 'token_type' field when successful " +
-            `and it must be one of ${OIDC_SUBJECT_TOKEN_TYPE1}, ${OIDC_SUBJECT_TOKEN_TYPE2}, or ${SAML_SUBJECT_TOKEN_TYPE}.`
-        );
       }
     } else {
       // Both code and message must be provided for unsuccessful responses.

--- a/src/auth/executableresponse.ts
+++ b/src/auth/executableresponse.ts
@@ -17,12 +17,12 @@ const OIDC_SUBJECT_TOKEN_TYPE1 = 'urn:ietf:params:oauth:token-type:id_token';
 const OIDC_SUBJECT_TOKEN_TYPE2 = 'urn:ietf:params:oauth:token-type:jwt';
 
 /**
- * Interface defining JSON format of response from 3rd party executable run by
+ * Interface defining JSON format of response from 3rd party executable used by
  * pluggable auth client.
  */
 export interface ExecutableResponseJson {
   /**
-   * Version of the response, only version 1 currently supported.
+   * The version of the JSON response. Only version 1 is currently supported.
    * Always required.
    */
   version: number;
@@ -61,8 +61,7 @@ export interface ExecutableResponseJson {
 }
 
 /**
- * Class defining a response from a 3rd party executable run by the pluggable
- * auth client.
+ * Defines the response of a 3rd party executable run by the pluggable auth client.
  */
 export class ExecutableResponse {
   readonly version: number;
@@ -91,7 +90,7 @@ export class ExecutableResponse {
     this.version = responseJson.version;
     this.success = responseJson.success;
 
-    // Check that fields required when response is successful exist.
+    // Validate required fields for a successful response.
     if (this.success) {
       if (!responseJson.expiration_time) {
         throw Error(
@@ -106,8 +105,7 @@ export class ExecutableResponse {
       this.expirationTime = responseJson.expiration_time;
       this.tokenType = responseJson.token_type;
 
-      // Check that type specific fields exist based on token_type provided and
-      // set subjectToken.
+      // Validate that token type and subject token value.
       if (this.tokenType === SAML_SUBJECT_TOKEN_TYPE) {
         if (!responseJson.saml_response) {
           throw Error(
@@ -133,7 +131,7 @@ export class ExecutableResponse {
         );
       }
     } else {
-      // Check that fields required for unsuccessful response exist.
+      // Both code and message must be provided for unsuccessful responses.
       if (!responseJson.code || !responseJson.message) {
         throw Error(
           "Executable response must contain a 'code' and 'message' field when unsuccessful."
@@ -145,7 +143,7 @@ export class ExecutableResponse {
   }
 
   /**
-   * @return a boolean representing if the response has a valid token. Returns
+   * @return A boolean representing if the response has a valid token. Returns
    * true when the response was successful and the token is not expired.
    */
   isValid(): boolean {
@@ -153,7 +151,7 @@ export class ExecutableResponse {
   }
 
   /**
-   * @return a boolean representing if the response is expired. Returns true if
+   * @return A boolean representing if the response is expired. Returns true if
    * the expiration_time field was not provided or if the provided time has
    * passed.
    */

--- a/src/auth/executableresponse.ts
+++ b/src/auth/executableresponse.ts
@@ -64,12 +64,36 @@ export interface ExecutableResponseJson {
  * Defines the response of a 3rd party executable run by the pluggable auth client.
  */
 export class ExecutableResponse {
+  /**
+   * The version of the Executable response. Only version 1 is currently supported.
+   */
   readonly version: number;
+  /**
+   * Whether the executable ran successfully.
+   */
   readonly success: boolean;
+  /**
+   * Epoch time for expiration of the token in seconds.
+   */
   readonly expirationTime?: number;
+  /**
+   * Type of subject token in the response, currently supported values are:
+   * urn:ietf:params:oauth:token-type:saml2
+   * urn:ietf:params:oauth:token-type:id_token
+   * urn:ietf:params:oauth:token-type:jwt
+   */
   readonly tokenType?: string;
+  /**
+   * Error code from executable.
+   */
   readonly errorCode?: string;
+  /**
+   * Error message from executable.
+   */
   readonly errorMessage?: string;
+  /**
+   * Subject token from executable, format depends on tokenType.
+   */
   readonly subjectToken?: string;
 
   /**

--- a/src/auth/externalclient.ts
+++ b/src/auth/externalclient.ts
@@ -29,10 +29,15 @@ import {
   IdentityPoolClientOptions,
 } from './identitypoolclient';
 import {AwsClient, AwsClientOptions} from './awsclient';
+import {
+  PluggableAuthClient,
+  PluggableAuthClientOptions,
+} from './pluggableauthclient';
 
 export type ExternalAccountClientOptions =
   | IdentityPoolClientOptions
-  | AwsClientOptions;
+  | AwsClientOptions
+  | PluggableAuthClientOptions;
 
 /**
  * Dummy class with no constructor. Developers are expected to use fromJSON.
@@ -43,7 +48,8 @@ export class ExternalAccountClient {
       'ExternalAccountClients should be initialized via: ' +
         'ExternalAccountClient.fromJSON(), ' +
         'directly via explicit constructors, eg. ' +
-        'new AwsClient(options), new IdentityPoolClient(options) or via ' +
+        'new AwsClient(options), new IdentityPoolClient(options), new' +
+        'PluggableAuthClientOptions, or via ' +
         'new GoogleAuth(options).getClient()'
     );
   }
@@ -67,6 +73,13 @@ export class ExternalAccountClient {
     if (options && options.type === EXTERNAL_ACCOUNT_TYPE) {
       if ((options as AwsClientOptions).credential_source?.environment_id) {
         return new AwsClient(options as AwsClientOptions, additionalOptions);
+      } else if (
+        (options as PluggableAuthClientOptions).credential_source?.command
+      ) {
+        return new PluggableAuthClient(
+          options as PluggableAuthClientOptions,
+          additionalOptions
+        );
       } else {
         return new IdentityPoolClient(
           options as IdentityPoolClientOptions,

--- a/src/auth/pluggableauthclient.ts
+++ b/src/auth/pluggableauthclient.ts
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/auth/pluggableauthclient.ts
+++ b/src/auth/pluggableauthclient.ts
@@ -20,22 +20,39 @@ import {RefreshOptions} from './oauth2client';
 import {ExecutableResponse} from './executableresponse';
 
 /**
- * Interface defining JSON format for pluggable auth credentials.
+ * Defines the credential source portion of the configuration for PluggableAuthClient.
+ *
+ * <p>Command is the only required field. If timeout_millis is not specified, the library will
+ * default to a 30-second timeout.
+ *
+ * <pre>
+ * Sample credential source for Pluggable Auth Client:
+ * {
+ *   ...
+ *   "credential_source": {
+ *     "executable": {
+ *       "command": "/path/to/get/credentials.sh --arg1=value1 --arg2=value2",
+ *       "timeout_millis": 5000,
+ *       "output_file": "/path/to/generated/cached/credentials"
+ *     }
+ *   }
+ * }
+ * </pre>
  */
 export interface PluggableAuthClientOptions
   extends BaseExternalAccountClientOptions {
   credential_source: {
     /**
-     * Command used to retrieve the 3rd party token.
+     * The command used to retrieve the 3rd party token.
      */
     command: string;
     /**
-     * Timeout for executable to run in milliseconds. If none is provided it
-     * will be set to default timeout.
+     * The timeout for executable to run in milliseconds. If none is provided it
+     * will be set to the default timeout of 30 seconds.
      */
     timeout_millis?: number;
     /**
-     * Optional output file location that will be checked for a cached response
+     * An optional output file location that will be checked for a cached response
      * from a previous run of the executable.
      */
     output_file?: string;
@@ -43,11 +60,11 @@ export interface PluggableAuthClientOptions
 }
 
 /**
- * Error class for errors thrown from executable run by PluggableAuthClient.
+ * Error thrown from the executable run by PluggableAuthClient.
  */
 export class ExecutableError extends Error {
   /**
-   * Exit code returned by the executable.
+   * The exit code returned by the executable.
    */
   readonly code: string;
 
@@ -60,53 +77,100 @@ export class ExecutableError extends Error {
 }
 
 /**
- * Default executable timeout when none is provided, in milliseconds.
+ * The default executable timeout when none is provided, in milliseconds.
  */
 const DEFAULT_EXECUTABLE_TIMEOUT_MILLIS = 30 * 1000;
 /**
- * Minimum allowed executable timeout in milliseconds.
+ * The minimum allowed executable timeout in milliseconds.
  */
 const MINIMUM_EXECUTABLE_TIMEOUT_MILLIS = 5 * 1000;
 /**
- * Maximum allowed executable timeout in milliseconds.
+ * The maximum allowed executable timeout in milliseconds.
  */
 const MAXIMUM_EXECUTABLE_TIMEOUT_MILLIS = 120 * 1000;
 
 /**
- * Environment variable to check to see if executable can be run.
+ * The environment variable to check to see if executable can be run.
  * Value must be set to '1' for the executable to run.
  */
 const GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES =
   'GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES';
 
 /**
- * Maximum currently supported executable version.
+ * The maximum currently supported executable version.
  */
 const MAXIMUM_EXECUTABLE_VERSION = 1;
 
 /**
- * Pluggable auth external account client. This is used to call a user provided
- * executable which returns a subject token to be exchanged for a
- * Google access token.
+ * PluggableAuthClient enables the exchange of workload identity pool external credentials for
+ * Google access tokens by retrieving 3rd party tokens through a user supplied executable. These
+ * scripts/executables are completely independent of the Google Cloud Auth libraries. These
+ * credentials plug into ADC and will call the specified executable to retrieve the 3rd party token
+ * to be exchanged for a Google access token.
+ *
+ * <p>To use these credentials, the GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES environment variable
+ * must be set to '1'. This is for security reasons.
+ *
+ * <p>Both OIDC and SAML are supported. The executable must adhere to a specific response format
+ * defined below.
+ *
+ * <p>The executable should print out the 3rd party token to STDOUT in JSON format. This is not
+ * required when an output_file is specified in the credential source, with the expectation being
+ * that the output file will contain the JSON response instead.
+ *
+ * <pre>
+ * OIDC response sample:
+ * {
+ *   "version": 1,
+ *   "success": true,
+ *   "token_type": "urn:ietf:params:oauth:token-type:id_token",
+ *   "id_token": "HEADER.PAYLOAD.SIGNATURE",
+ *   "expiration_time": 1620433341
+ * }
+ *
+ * SAML2 response sample:
+ * {
+ *   "version": 1,
+ *   "success": true,
+ *   "token_type": "urn:ietf:params:oauth:token-type:saml2",
+ *   "saml_response": "...",
+ *   "expiration_time": 1620433341
+ * }
+ *
+ * Error response sample:
+ * {
+ *   "version": 1,
+ *   "success": false,
+ *   "code": "401",
+ *   "message": "Error message."
+ * }
+ *
+ * The auth libraries will populate certain environment variables that will be accessible by the
+ * executable, such as: GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE, GOOGLE_EXTERNAL_ACCOUNT_TOKEN_TYPE,
+ * GOOGLE_EXTERNAL_ACCOUNT_INTERACTIVE, GOOGLE_EXTERNAL_ACCOUNT_IMPERSONATED_EMAIL, and
+ * GOOGLE_EXTERNAL_ACCOUNT_OUTPUT_FILE.
+ *
+ * <p>Please see this repositories README for a complete executable request/response specification.
+ * </pre>
  */
 export class PluggableAuthClient extends BaseExternalAccountClient {
   /**
-   * Command used to retrieve the third party token.
+   * The command used to retrieve the third party token.
    */
   private readonly command: string;
   /**
-   * Timeout in milliseconds for running executable,
+   * The timeout in milliseconds for running executable,
    * set to default if none provided.
    */
   private readonly timeoutMillis: number;
   /**
-   * Path to file to check for cached executable response.
+   * The path to file to check for cached executable response.
    */
   private readonly outputFile?: string;
 
   /**
    * Instantiates a PluggableAuthClient instance using the provided JSON
-   * Object loaded from an external account credentials file.
+   * object loaded from an external account credentials file.
    * An error is thrown if the credential is not a valid pluggable auth credential.
    * @param options The external account options object typically loaded from
    *   the external account JSON credential file.

--- a/src/auth/pluggableauthclient.ts
+++ b/src/auth/pluggableauthclient.ts
@@ -1,0 +1,253 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  BaseExternalAccountClient,
+  BaseExternalAccountClientOptions,
+} from './baseexternalclient';
+import {RefreshOptions} from './oauth2client';
+import {ExecutableResponse} from './executableresponse';
+
+/**
+ * Interface defining JSON format for pluggable auth credentials.
+ */
+export interface PluggableAuthClientOptions
+  extends BaseExternalAccountClientOptions {
+  credential_source: {
+    /**
+     * Command used to retrieve the 3rd party token.
+     */
+    command: string;
+    /**
+     * Timeout for executable to run in milliseconds. If none is provided it
+     * will be set to default timeout.
+     */
+    timeout_millis?: number;
+    /**
+     * Optional output file location that will be checked for a cached response
+     * from a previous run of the executable.
+     */
+    output_file?: string;
+  };
+}
+
+/**
+ * Error class for errors thrown from executable run by PluggableAuthClient.
+ */
+export class ExecutableError extends Error {
+  /**
+   * Exit code returned by the executable.
+   */
+  readonly code: string;
+
+  constructor(message: string, code: string) {
+    super(message);
+    this.name = 'ExecutableError';
+    this.code = code;
+    Object.setPrototypeOf(this, ExecutableError.prototype);
+  }
+}
+
+/**
+ * Default executable timeout when none is provided, in milliseconds.
+ */
+const DEFAULT_EXECUTABLE_TIMEOUT_MILLIS = 30 * 1000;
+/**
+ * Minimum allowed executable timeout in milliseconds.
+ */
+const MINIMUM_EXECUTABLE_TIMEOUT_MILLIS = 5 * 1000;
+/**
+ * Maximum allowed executable timeout in milliseconds.
+ */
+const MAXIMUM_EXECUTABLE_TIMEOUT_MILLIS = 120 * 1000;
+
+/**
+ * Environment variable to check to see if executable can be run.
+ * Value must be set to '1' for the executable to run.
+ */
+const GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES =
+  'GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES';
+
+/**
+ * Maximum currently supported executable version.
+ */
+const MAXIMUM_EXECUTABLE_VERSION = 1;
+
+/**
+ * Pluggable auth external account client. This is used to call a user provided
+ * executable which returns a subject token to be exchanged for a
+ * Google access token.
+ */
+export class PluggableAuthClient extends BaseExternalAccountClient {
+  /**
+   * Command used to retrieve the third party token.
+   */
+  private readonly command: string;
+  /**
+   * Timeout in milliseconds for running executable,
+   * set to default if none provided.
+   */
+  private readonly timeoutMillis: number;
+  /**
+   * Path to file to check for cached executable response.
+   */
+  private readonly outputFile?: string;
+
+  /**
+   * Instantiates a PluggableAuthClient instance using the provided JSON
+   * Object loaded from an external account credentials file.
+   * An error is thrown if the credential is not a valid pluggable auth credential.
+   * @param options The external account options object typically loaded from
+   *   the external account JSON credential file.
+   * @param additionalOptions Optional additional behavior customization
+   *   options. These currently customize expiration threshold time and
+   *   whether to retry on 401/403 API request errors.
+   */
+  constructor(
+    options: PluggableAuthClientOptions,
+    additionalOptions?: RefreshOptions
+  ) {
+    super(options, additionalOptions);
+    this.command = options.credential_source.command;
+    if (!this.command) {
+      throw new Error('No valid Pluggable Auth "credential_source" provided.');
+    }
+    //Check if the provided timeout exists and if it is valid.
+    if (options.credential_source.timeout_millis === undefined) {
+      this.timeoutMillis = DEFAULT_EXECUTABLE_TIMEOUT_MILLIS;
+    } else {
+      this.timeoutMillis = options.credential_source.timeout_millis;
+      if (
+        this.timeoutMillis < MINIMUM_EXECUTABLE_TIMEOUT_MILLIS ||
+        this.timeoutMillis > MAXIMUM_EXECUTABLE_TIMEOUT_MILLIS
+      ) {
+        throw new Error(
+          `Timeout must be between ${MINIMUM_EXECUTABLE_TIMEOUT_MILLIS} and ` +
+            `${MAXIMUM_EXECUTABLE_TIMEOUT_MILLIS} milliseconds.`
+        );
+      }
+    }
+
+    this.outputFile = options.credential_source.output_file;
+  }
+
+  /**
+   * Triggered when an external subject token is needed to be exchanged for a
+   * GCP access token via GCP STS endpoint.
+   * This uses the `options.credential_source` object to figure out how
+   * to retrieve the token using the current environment. In this case,
+   * this calls a user provided executable which returns the subject token.
+   * The logic is summarized as:
+   * 1. Validated that the executable is allowed to run. The
+   *    GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES environment must be set to
+   *    1 for security reasons.
+   * 2. If an output file is specified by the user, check the file location
+   *    for a response. If the file exists and contains a valid response,
+   *    return the subject token from the file.
+   * 3. Call the provided executable and return response.
+   * @return A promise that resolves with the external subject token.
+   */
+  async retrieveSubjectToken(): Promise<string> {
+    // Check if the executable is allowed to run.
+    if (process.env[GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES] !== '1') {
+      throw new Error(
+        'Pluggable Auth executables need to be explicitly allowed to run by ' +
+          'setting the GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES environment ' +
+          'Variable to 1.'
+      );
+    }
+
+    let executableResponse: ExecutableResponse | undefined;
+    // Try to get cached executable response from output file
+    if (this.outputFile) {
+      executableResponse = await this.retrieveCachedResponse();
+    }
+
+    // If no response from output file, call the executable
+    if (!executableResponse) {
+      // Set up environment map with required values for the executable
+      const envMap = new Map();
+      envMap.set('GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE', this.audience);
+      envMap.set('GOOGLE_EXTERNAL_ACCOUNT_TOKEN_TYPE', this.subjectTokenType);
+      // Set to 0 for workloadIdentityFederation
+      envMap.set('GOOGLE_EXTERNAL_ACCOUNT_INTERACTIVE', '0');
+      const serviceAccountEmail = this.getServiceAccountEmail();
+      if (serviceAccountEmail) {
+        envMap.set(
+          'GOOGLE_EXTERNAL_ACCOUNT_IMPERSONATED_EMAIL',
+          serviceAccountEmail
+        );
+      }
+      executableResponse = await this.retrieveResponseFromExecutable(envMap);
+    }
+
+    if (executableResponse) {
+      // Check that version of response is valid.
+      if (executableResponse.version > MAXIMUM_EXECUTABLE_VERSION) {
+        throw new Error(
+          `Version of executable is not currently supported, maximum supported version is ${MAXIMUM_EXECUTABLE_VERSION}.`
+        );
+      }
+      // Check that response was successful.
+      if (!executableResponse.success) {
+        throw new ExecutableError(
+          executableResponse.errorMessage as string,
+          executableResponse.errorCode as string
+        );
+      }
+      // Check that response is not expired.
+      if (executableResponse.isExpired()) {
+        throw new Error('Executable response is expired.');
+      }
+      // Return subject token from response.
+      return executableResponse.subjectToken as string;
+    } else {
+      throw new Error('No valid response returned from executable.');
+    }
+  }
+
+  /**
+   * Calls user provided executable to get a 3rd party subject token and
+   * returns the response.
+   * @param envMap a Map of additional Environment Variables required for
+   *   the executable.
+   * @return A promise that resolves with the executable response.
+   */
+  private retrieveResponseFromExecutable(
+    envMap: Map<string, string>
+  ): Promise<ExecutableResponse> {
+    // TODO: Implement running executable and retrieving response.
+    return new Promise(resolve => {
+      const responseJson = {
+        success: false,
+        version: 1,
+        code: '',
+        message: '',
+      };
+      const response = new ExecutableResponse(responseJson);
+      resolve(response);
+    });
+  }
+
+  /**
+   * Checks user provided output file for response from previous run of
+   * executable and return the response if it exists and is valid.
+   */
+  private retrieveCachedResponse(): Promise<ExecutableResponse | undefined> {
+    // TODO: Implement output file reading.
+    return new Promise(resolve => {
+      resolve(undefined);
+    });
+  }
+}

--- a/src/auth/pluggableauthclient.ts
+++ b/src/auth/pluggableauthclient.ts
@@ -123,7 +123,7 @@ export class PluggableAuthClient extends BaseExternalAccountClient {
     if (!this.command) {
       throw new Error('No valid Pluggable Auth "credential_source" provided.');
     }
-    //Check if the provided timeout exists and if it is valid.
+    // Check if the provided timeout exists and if it is valid.
     if (options.credential_source.timeout_millis === undefined) {
       this.timeoutMillis = DEFAULT_EXECUTABLE_TIMEOUT_MILLIS;
     } else {
@@ -169,18 +169,18 @@ export class PluggableAuthClient extends BaseExternalAccountClient {
     }
 
     let executableResponse: ExecutableResponse | undefined;
-    // Try to get cached executable response from output file
+    // Try to get cached executable response from output file.
     if (this.outputFile) {
       executableResponse = await this.retrieveCachedResponse();
     }
 
-    // If no response from output file, call the executable
+    // If no response from output file, call the executable.
     if (!executableResponse) {
-      // Set up environment map with required values for the executable
+      // Set up environment map with required values for the executable.
       const envMap = new Map();
       envMap.set('GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE', this.audience);
       envMap.set('GOOGLE_EXTERNAL_ACCOUNT_TOKEN_TYPE', this.subjectTokenType);
-      // Set to 0 for workloadIdentityFederation
+      // Always set to 0 because interactive mode is not supported.
       envMap.set('GOOGLE_EXTERNAL_ACCOUNT_INTERACTIVE', '0');
       const serviceAccountEmail = this.getServiceAccountEmail();
       if (serviceAccountEmail) {

--- a/test/test.executableresponse.ts
+++ b/test/test.executableresponse.ts
@@ -1,0 +1,344 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import {describe, it} from 'mocha';
+import {ExecutableResponse} from '../src/auth/executableresponse';
+import * as sinon from 'sinon';
+
+const SAML_SUBJECT_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:saml2';
+const OIDC_SUBJECT_TOKEN_TYPE1 = 'urn:ietf:params:oauth:token-type:id_token';
+const OIDC_SUBJECT_TOKEN_TYPE2 = 'urn:ietf:params:oauth:token-type:jwt';
+
+describe('ExecutableResponse', () => {
+  let clock: sinon.SinonFakeTimers;
+  const referenceTime = 1653429377000;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers({now: referenceTime});
+  });
+
+  afterEach(() => {
+    if (clock) {
+      clock.restore();
+    }
+  });
+
+  describe('Constructor', () => {
+    it('should throw error when version field is missing', () => {
+      const responseJson = {
+        success: 'true',
+      };
+      const expectedError = new Error(
+        "Executable response must contain a 'version' field."
+      );
+
+      assert.throws(() => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        return new ExecutableResponse(responseJson);
+      }, expectedError);
+    });
+
+    it('should throw error when success field is missing', () => {
+      const responseJson = {
+        version: 1,
+      };
+      const expectedError = new Error(
+        "Executable response must contain a 'success' field."
+      );
+
+      assert.throws(() => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        return new ExecutableResponse(responseJson);
+      }, expectedError);
+    });
+
+    it('should throw error when expiration_time field is missing and success = true', () => {
+      const responseJson = {
+        success: true,
+        version: 1,
+        token_type: OIDC_SUBJECT_TOKEN_TYPE1,
+      };
+      const expectedError = new Error(
+        "Executable response must contain an 'expiration_time' field when successful."
+      );
+
+      assert.throws(() => {
+        return new ExecutableResponse(responseJson);
+      }, expectedError);
+    });
+
+    it('should throw error when token_type field is missing and success = true', () => {
+      const responseJson = {
+        success: true,
+        version: 1,
+        expiration_time: 123456,
+      };
+      const expectedError = new Error(
+        "Executable response must contain a 'token_type' field when successful."
+      );
+
+      assert.throws(() => {
+        return new ExecutableResponse(responseJson);
+      }, expectedError);
+    });
+
+    it('should throw error when token_type field is invalid and success = true', () => {
+      const responseJson = {
+        success: true,
+        version: 1,
+        expiration_time: 123456,
+        token_type: 'invalidExample',
+      };
+      const expectedError = new Error(
+        "Executable response must contain a 'token_type' field when successful and it must be one of urn:ietf:params:oauth:token-type:id_token, urn:ietf:params:oauth:token-type:jwt, or urn:ietf:params:oauth:token-type:saml2."
+      );
+
+      assert.throws(() => {
+        return new ExecutableResponse(responseJson);
+      }, expectedError);
+    });
+
+    it('should throw error when id_token field is missing and token_type is OIDC', () => {
+      const responseJson = {
+        success: true,
+        version: 1,
+        expiration_time: 123456,
+        token_type: OIDC_SUBJECT_TOKEN_TYPE1,
+        saml_response: 'response',
+      };
+      const expectedError = new Error(
+        "Executable response must contain a 'id_token' field when token_type=urn:ietf:params:oauth:token-type:id_token or urn:ietf:params:oauth:token-type:jwt."
+      );
+
+      assert.throws(() => {
+        return new ExecutableResponse(responseJson);
+      }, expectedError);
+    });
+
+    it('should throw error when saml_response field is missing and token_type is SAML', () => {
+      const responseJson = {
+        success: true,
+        version: 1,
+        expiration_time: 123456,
+        token_type: SAML_SUBJECT_TOKEN_TYPE,
+        id_token: 'response',
+      };
+      const expectedError = new Error(
+        "Executable response must contain a 'saml_response' field when token_type=urn:ietf:params:oauth:token-type:saml2."
+      );
+
+      assert.throws(() => {
+        return new ExecutableResponse(responseJson);
+      }, expectedError);
+    });
+
+    it('should throw error when code field is missing and success is false', () => {
+      const responseJson = {
+        success: false,
+        version: 1,
+        message: 'error message',
+      };
+      const expectedError = new Error(
+        "Executable response must contain a 'code' and 'message' field when unsuccessful."
+      );
+
+      assert.throws(() => {
+        return new ExecutableResponse(responseJson);
+      }, expectedError);
+    });
+
+    it('should throw error when message field is missing and success is false', () => {
+      const responseJson = {
+        success: false,
+        version: 1,
+        code: '1',
+      };
+      const expectedError = new Error(
+        "Executable response must contain a 'code' and 'message' field when unsuccessful."
+      );
+
+      assert.throws(() => {
+        return new ExecutableResponse(responseJson);
+      }, expectedError);
+    });
+
+    it('should should set properties correctly for a successful response with saml', () => {
+      const responseJson = {
+        success: true,
+        version: 1,
+        token_type: SAML_SUBJECT_TOKEN_TYPE,
+        expiration_time: 123456,
+        saml_response: 'response',
+      };
+
+      const executableResponse = new ExecutableResponse(responseJson);
+
+      assert.equal(executableResponse.success, responseJson.success);
+      assert.equal(executableResponse.version, responseJson.version);
+      assert.equal(executableResponse.tokenType, responseJson.token_type);
+      assert.equal(
+        executableResponse.expirationTime,
+        responseJson.expiration_time
+      );
+      assert.equal(executableResponse.subjectToken, responseJson.saml_response);
+    });
+
+    it('should should set properties correctly for a successful response with OIDC type 1', () => {
+      const responseJson = {
+        success: true,
+        version: 1,
+        token_type: OIDC_SUBJECT_TOKEN_TYPE1,
+        expiration_time: 123456,
+        id_token: 'response',
+      };
+
+      const executableResponse = new ExecutableResponse(responseJson);
+
+      assert.equal(executableResponse.success, responseJson.success);
+      assert.equal(executableResponse.version, responseJson.version);
+      assert.equal(executableResponse.tokenType, responseJson.token_type);
+      assert.equal(
+        executableResponse.expirationTime,
+        responseJson.expiration_time
+      );
+      assert.equal(executableResponse.subjectToken, responseJson.id_token);
+    });
+
+    it('should should set properties correctly for a successful response with OIDC type 2', () => {
+      const responseJson = {
+        success: true,
+        version: 1,
+        token_type: OIDC_SUBJECT_TOKEN_TYPE2,
+        expiration_time: 123456,
+        id_token: 'response',
+      };
+
+      const executableResponse = new ExecutableResponse(responseJson);
+
+      assert.equal(executableResponse.success, responseJson.success);
+      assert.equal(executableResponse.version, responseJson.version);
+      assert.equal(executableResponse.tokenType, responseJson.token_type);
+      assert.equal(
+        executableResponse.expirationTime,
+        responseJson.expiration_time
+      );
+      assert.equal(executableResponse.subjectToken, responseJson.id_token);
+    });
+
+    it('should should set properties correctly for unsuccessful response', () => {
+      const responseJson = {
+        success: false,
+        version: 1,
+        code: '1',
+        message: 'error message',
+      };
+
+      const executableResponse = new ExecutableResponse(responseJson);
+
+      assert.equal(executableResponse.success, responseJson.success);
+      assert.equal(executableResponse.version, responseJson.version);
+      assert.equal(executableResponse.errorCode, responseJson.code);
+      assert.equal(executableResponse.errorMessage, responseJson.message);
+    });
+  });
+
+  describe('isExpired', () => {
+    it('should return true if response does not contain expirationTime', () => {
+      const responseJson = {
+        success: false,
+        version: 1,
+        code: '1',
+        message: 'error message',
+      };
+
+      const executableResponse = new ExecutableResponse(responseJson);
+
+      assert.equal(true, executableResponse.isExpired());
+    });
+
+    it('should return true if response is expired', () => {
+      const responseJson = {
+        success: true,
+        version: 1,
+        token_type: SAML_SUBJECT_TOKEN_TYPE,
+        saml_response: 'response',
+        expiration_time: referenceTime / 1000 - 1,
+      };
+
+      const executableResponse = new ExecutableResponse(responseJson);
+
+      assert.equal(true, executableResponse.isExpired());
+    });
+
+    it('should return false if response is not expired', () => {
+      const responseJson = {
+        success: true,
+        version: 1,
+        token_type: SAML_SUBJECT_TOKEN_TYPE,
+        saml_response: 'response',
+        expiration_time: referenceTime / 1000 + 1,
+      };
+
+      const executableResponse = new ExecutableResponse(responseJson);
+
+      assert.equal(false, executableResponse.isExpired());
+    });
+  });
+
+  describe('isValid', () => {
+    it('should return false if response is not successful', () => {
+      const responseJson = {
+        success: false,
+        version: 1,
+        code: '1',
+        message: 'error message',
+      };
+
+      const executableResponse = new ExecutableResponse(responseJson);
+
+      assert.equal(false, executableResponse.isValid());
+    });
+
+    it('should return false if response is successful but expired', () => {
+      const responseJson = {
+        success: true,
+        version: 1,
+        expiration_time: referenceTime / 1000 - 1,
+        token_type: SAML_SUBJECT_TOKEN_TYPE,
+        saml_response: 'response',
+      };
+
+      const executableResponse = new ExecutableResponse(responseJson);
+
+      assert.equal(false, executableResponse.isValid());
+    });
+
+    it('should return true if response is successful and not expired', () => {
+      const responseJson = {
+        success: true,
+        version: 1,
+        expiration_time: referenceTime / 1000 + 1,
+        token_type: SAML_SUBJECT_TOKEN_TYPE,
+        saml_response: 'response',
+      };
+
+      const executableResponse = new ExecutableResponse(responseJson);
+
+      assert.equal(true, executableResponse.isValid());
+    });
+  });
+});

--- a/test/test.executableresponse.ts
+++ b/test/test.executableresponse.ts
@@ -14,7 +14,16 @@
 
 import * as assert from 'assert';
 import {describe, it} from 'mocha';
-import {ExecutableResponse} from '../src/auth/executableresponse';
+import {
+  ExecutableResponse,
+  InvalidSubjectTokenError,
+  InvalidTokenTypeFieldError,
+  InvalidCodeFieldError,
+  InvalidExpirationTimeFieldError,
+  InvalidMessageFieldError,
+  InvalidSuccessFieldError,
+  InvalidVersionFieldError,
+} from '../src/auth/executableresponse';
 import * as sinon from 'sinon';
 
 const SAML_SUBJECT_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:saml2';
@@ -40,7 +49,7 @@ describe('ExecutableResponse', () => {
       const responseJson = {
         success: 'true',
       };
-      const expectedError = new Error(
+      const expectedError = new InvalidVersionFieldError(
         "Executable response must contain a 'version' field."
       );
 
@@ -55,7 +64,7 @@ describe('ExecutableResponse', () => {
       const responseJson = {
         version: 1,
       };
-      const expectedError = new Error(
+      const expectedError = new InvalidSuccessFieldError(
         "Executable response must contain a 'success' field."
       );
 
@@ -72,7 +81,7 @@ describe('ExecutableResponse', () => {
         version: 1,
         token_type: OIDC_SUBJECT_TOKEN_TYPE1,
       };
-      const expectedError = new Error(
+      const expectedError = new InvalidExpirationTimeFieldError(
         "Executable response must contain an 'expiration_time' field when successful."
       );
 
@@ -87,8 +96,9 @@ describe('ExecutableResponse', () => {
         version: 1,
         expiration_time: 123456,
       };
-      const expectedError = new Error(
-        "Executable response must contain a 'token_type' field when successful."
+      const expectedError = new InvalidTokenTypeFieldError(
+        "Executable response must contain a 'token_type' field when successful " +
+          `and it must be one of ${OIDC_SUBJECT_TOKEN_TYPE1}, ${OIDC_SUBJECT_TOKEN_TYPE2}, or ${SAML_SUBJECT_TOKEN_TYPE}.`
       );
 
       assert.throws(() => {
@@ -103,8 +113,9 @@ describe('ExecutableResponse', () => {
         expiration_time: 123456,
         token_type: 'invalidExample',
       };
-      const expectedError = new Error(
-        "Executable response must contain a 'token_type' field when successful and it must be one of urn:ietf:params:oauth:token-type:id_token, urn:ietf:params:oauth:token-type:jwt, or urn:ietf:params:oauth:token-type:saml2."
+      const expectedError = new InvalidTokenTypeFieldError(
+        "Executable response must contain a 'token_type' field when successful " +
+          `and it must be one of ${OIDC_SUBJECT_TOKEN_TYPE1}, ${OIDC_SUBJECT_TOKEN_TYPE2}, or ${SAML_SUBJECT_TOKEN_TYPE}.`
       );
 
       assert.throws(() => {
@@ -120,7 +131,7 @@ describe('ExecutableResponse', () => {
         token_type: OIDC_SUBJECT_TOKEN_TYPE1,
         saml_response: 'response',
       };
-      const expectedError = new Error(
+      const expectedError = new InvalidSubjectTokenError(
         "Executable response must contain a 'id_token' field when token_type=urn:ietf:params:oauth:token-type:id_token or urn:ietf:params:oauth:token-type:jwt."
       );
 
@@ -137,7 +148,7 @@ describe('ExecutableResponse', () => {
         token_type: SAML_SUBJECT_TOKEN_TYPE,
         id_token: 'response',
       };
-      const expectedError = new Error(
+      const expectedError = new InvalidSubjectTokenError(
         "Executable response must contain a 'saml_response' field when token_type=urn:ietf:params:oauth:token-type:saml2."
       );
 
@@ -152,8 +163,8 @@ describe('ExecutableResponse', () => {
         version: 1,
         message: 'error message',
       };
-      const expectedError = new Error(
-        "Executable response must contain a 'code' and 'message' field when unsuccessful."
+      const expectedError = new InvalidCodeFieldError(
+        "Executable response must contain a 'code' field when unsuccessful."
       );
 
       assert.throws(() => {
@@ -167,8 +178,8 @@ describe('ExecutableResponse', () => {
         version: 1,
         code: '1',
       };
-      const expectedError = new Error(
-        "Executable response must contain a 'code' and 'message' field when unsuccessful."
+      const expectedError = new InvalidMessageFieldError(
+        "Executable response must contain a 'message' field when unsuccessful."
       );
 
       assert.throws(() => {

--- a/test/test.externalclient.ts
+++ b/test/test.externalclient.ts
@@ -18,6 +18,7 @@ import {AwsClient} from '../src/auth/awsclient';
 import {IdentityPoolClient} from '../src/auth/identitypoolclient';
 import {ExternalAccountClient} from '../src/auth/externalclient';
 import {getAudience, getTokenUrl} from './externalclienthelper';
+import {PluggableAuthClient} from '../src/auth/pluggableauthclient';
 
 const serviceAccountKeys = {
   type: 'service_account',
@@ -60,6 +61,19 @@ const awsOptions = {
   subject_token_type: 'urn:ietf:params:aws:token-type:aws4_request',
   token_url: getTokenUrl(),
   credential_source: awsCredentialSource,
+};
+
+const pluggableAuthCredentialSource = {
+  command: 'exampleCommand',
+  timeout_millis: 30000,
+  output_file: 'output.txt',
+};
+const pluggableAuthClientOptions = {
+  type: 'external_account',
+  audience: getAudience(),
+  subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
+  token_url: getTokenUrl(),
+  credential_source: pluggableAuthCredentialSource,
 };
 
 describe('ExternalAccountClient', () => {
@@ -159,6 +173,32 @@ describe('ExternalAccountClient', () => {
       }
     });
 
+    it('should return PluggableAuthClient on PluggableAuthClientOptions', () => {
+      const expectedClient = new PluggableAuthClient(
+        pluggableAuthClientOptions
+      );
+
+      assert.deepStrictEqual(
+        ExternalAccountClient.fromJSON(pluggableAuthClientOptions),
+        expectedClient
+      );
+    });
+
+    it('should return PluggableAuthClient with expected RefreshOptions', () => {
+      const expectedClient = new PluggableAuthClient(
+        pluggableAuthClientOptions,
+        refreshOptions
+      );
+
+      assert.deepStrictEqual(
+        ExternalAccountClient.fromJSON(
+          pluggableAuthClientOptions,
+          refreshOptions
+        ),
+        expectedClient
+      );
+    });
+
     invalidWorkforceIdentityPoolClientAudiences.forEach(
       invalidWorkforceIdentityPoolClientAudience => {
         const workforceIdentityPoolClientInvalidOptions = Object.assign(
@@ -212,6 +252,16 @@ describe('ExternalAccountClient', () => {
     it('should throw when given invalid AwsClientOptions', () => {
       const invalidOptions = Object.assign({}, awsOptions);
       invalidOptions.credential_source.environment_id = 'invalid';
+
+      assert.throws(() => {
+        return ExternalAccountClient.fromJSON(invalidOptions);
+      });
+    });
+
+    it('should throw when given invalid PluggableAuthClientOptions', () => {
+      const invalidOptions = Object.assign({}, pluggableAuthClientOptions);
+      invalidOptions.credential_source.command = 'command';
+      invalidOptions.credential_source.timeout_millis = -1;
 
       assert.throws(() => {
         return ExternalAccountClient.fromJSON(invalidOptions);

--- a/test/test.pluggableauthclient.ts
+++ b/test/test.pluggableauthclient.ts
@@ -46,6 +46,7 @@ describe('PluggableAuthClient', () => {
         {},
         pluggableAuthCredentialSource
       );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       delete (invalidCredentialSource as any)['command'];
       const invalidOptions = {
         type: 'external_account',

--- a/test/test.pluggableauthclient.ts
+++ b/test/test.pluggableauthclient.ts
@@ -1,0 +1,129 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import {PluggableAuthClient} from '../src/auth/pluggableauthclient';
+import {BaseExternalAccountClient} from '../src';
+import {getAudience, getTokenUrl} from './externalclienthelper';
+import {beforeEach} from 'mocha';
+
+describe('PluggableAuthClient', () => {
+  const audience = getAudience();
+  const pluggableAuthCredentialSource = {
+    command: './command',
+    output_file: 'output.txt',
+    timeout_millis: 10000,
+  };
+  const pluggableAuthOptions = {
+    type: 'external_account',
+    audience,
+    subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
+    token_url: getTokenUrl(),
+    credential_source: pluggableAuthCredentialSource,
+  };
+
+  it('should be a subclass of ExternalAccountClient', () => {
+    assert(PluggableAuthClient.prototype instanceof BaseExternalAccountClient);
+  });
+
+  describe('Constructor', () => {
+    it('should throw when credential_source is missing command', () => {
+      const expectedError = new Error(
+        'No valid Pluggable Auth "credential_source" provided.'
+      );
+      const invalidCredentialSource = Object.assign(
+        {},
+        pluggableAuthCredentialSource
+      );
+      delete (invalidCredentialSource as any)['command'];
+      const invalidOptions = {
+        type: 'external_account',
+        audience,
+        subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
+        token_url: getTokenUrl(),
+        credential_source: invalidCredentialSource,
+      };
+
+      assert.throws(() => {
+        return new PluggableAuthClient(invalidOptions);
+      }, expectedError);
+    });
+
+    it('should throw when time_millis is below minimum allowed value', () => {
+      const expectedError = new Error(
+        'Timeout must be between 5000 and 120000 milliseconds.'
+      );
+      const invalidCredentialSource = Object.assign(
+        {},
+        pluggableAuthCredentialSource
+      );
+      invalidCredentialSource.timeout_millis = 0;
+      const invalidOptions = {
+        type: 'external_account',
+        audience,
+        subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
+        token_url: getTokenUrl(),
+        credential_source: invalidCredentialSource,
+      };
+
+      assert.throws(() => {
+        return new PluggableAuthClient(invalidOptions);
+      }, expectedError);
+    });
+
+    it('should throw when time_millis is above maximum allowed value', () => {
+      const expectedError = new Error(
+        'Timeout must be between 5000 and 120000 milliseconds.'
+      );
+      const invalidCredentialSource = Object.assign(
+        {},
+        pluggableAuthCredentialSource
+      );
+      invalidCredentialSource.timeout_millis = 9000000000;
+      const invalidOptions = {
+        type: 'external_account',
+        audience,
+        subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
+        token_url: getTokenUrl(),
+        credential_source: invalidCredentialSource,
+      };
+
+      assert.throws(() => {
+        return new PluggableAuthClient(invalidOptions);
+      }, expectedError);
+    });
+  });
+
+  describe('RetrieveSubjectToken', () => {
+    beforeEach(() => {
+      // Set Allow Executables environment variables to 1
+      process.env.GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES = '1';
+    });
+
+    afterEach(() => {
+      delete process.env.GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES;
+    });
+
+    it('should throw when allow executables environment variables is not 1', async () => {
+      process.env.GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES = '0';
+      const expectedError = new Error(
+        'Pluggable Auth executables need to be explicitly allowed to run by setting the GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES environment Variable to 1.'
+      );
+
+      const client = new PluggableAuthClient(pluggableAuthOptions);
+
+      await assert.rejects(client.retrieveSubjectToken(), expectedError);
+    });
+  });
+});


### PR DESCRIPTION
See go/pluggable-auth-design.
Adding classes required for supporting pluggable auth and some functionality.
Will add the implementation for running the executable and reading from a cached file in a later pull request.
