### PR TITLE
feat: adding configurable token lifespan support

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -351,8 +351,6 @@ body: |-
       projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$POOL_ID/providers/$AWS_PROVIDER_ID \
       --service-account $SERVICE_ACCOUNT_EMAIL \
       --aws \
-      # Optional argument for specifying the duration of the service account access token.
-      # --service-account-token-lifetime-seconds $TOKEN_LIFETIME \
       --output-file /path/to/generated/config.json
   ```
 
@@ -361,11 +359,8 @@ body: |-
   - `$POOL_ID`: The workload identity pool ID.
   - `$AWS_PROVIDER_ID`: The AWS provider ID.
   - `$SERVICE_ACCOUNT_EMAIL`: The email of the service account to impersonate.
-  - `$TOKEN_LIFETIME`: The desired lifetime duration of the service account access token in seconds.
   
   This will generate the configuration file in the specified output file.
-
-  The `service-account-token-lifetime-seconds` flag is optional. If not provided, this defaults to one hour. If a lifetime greater than one hour is required, the service account must be added as an allowed value in an Organization Policy that enforces the `constraints/iam.allowServiceAccountCredentialLifetimeExtension` constraint.
 
   If you want to use the AWS IMDSv2 flow, you can add the field below to the credential_source in your AWS ADC configuration file:
   "imdsv2_session_token_url": "http://169.254.169.254/latest/api/token"
@@ -395,8 +390,6 @@ body: |-
       projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$POOL_ID/providers/$AZURE_PROVIDER_ID \
       --service-account $SERVICE_ACCOUNT_EMAIL \
       --azure \
-      # Optional argument for specifying the duration of the service account access token.
-      # --service-account-token-lifetime-seconds $TOKEN_LIFETIME \
       --output-file /path/to/generated/config.json
   ```
 
@@ -405,11 +398,8 @@ body: |-
   - `$POOL_ID`: The workload identity pool ID.
   - `$AZURE_PROVIDER_ID`: The Azure provider ID.
   - `$SERVICE_ACCOUNT_EMAIL`: The email of the service account to impersonate.
-  - `$TOKEN_LIFETIME`: The desired lifetime duration of the service account access token in seconds.
   
   This will generate the configuration file in the specified output file.
-
-  The `service-account-token-lifetime-seconds` flag is optional. If not provided, this defaults to one hour. If a lifetime greater than one hour is required, the service account must be added as an allowed value in an Organization Policy that enforces the `constraints/iam.allowServiceAccountCredentialLifetimeExtension` constraint.
 
   You can now [start using the Auth library](#using-external-identities) to call Google Cloud resources from Azure.
 
@@ -445,8 +435,6 @@ body: |-
       # Optional argument for the field that contains the OIDC credential.
       # This is required for json.
       # --credential-source-field-name "id_token" \
-      # Optional argument for specifying the duration of the service account access token.
-      # --service-account-token-lifetime-seconds $TOKEN_LIFETIME \
       --output-file /path/to/generated/config.json
   ```
 
@@ -456,11 +444,8 @@ body: |-
   - `$OIDC_PROVIDER_ID`: The OIDC provider ID.
   - `$SERVICE_ACCOUNT_EMAIL`: The email of the service account to impersonate.
   - `$PATH_TO_OIDC_ID_TOKEN`: The file path where the OIDC token will be retrieved from.
-  - `$TOKEN_LIFETIME`: The desired lifetime duration of the service account access token in seconds.
   
   This will generate the configuration file in the specified output file.
-
-  The `service-account-token-lifetime-seconds` flag is optional. If not provided, this defaults to one hour. If a lifetime greater than one hour is required, the service account must be added as an allowed value in an Organization Policy that enforces the `constraints/iam.allowServiceAccountCredentialLifetimeExtension` constraint.
 
   **URL-sourced credentials**
   For URL-sourced credentials, a local server needs to host a GET endpoint to return the OIDC token. The response can be in plain text or JSON.
@@ -480,8 +465,6 @@ body: |-
       # Optional argument for the field that contains the OIDC credential.
       # This is required for json.
       # --credential-source-field-name "id_token" \
-      # Optional argument for specifying the duration of the service account access token.
-      # --service-account-token-lifetime-seconds $TOKEN_LIFETIME \
       --output-file /path/to/generated/config.json
   ```
 
@@ -492,10 +475,7 @@ body: |-
   - `$SERVICE_ACCOUNT_EMAIL`: The email of the service account to impersonate.
   - `$URL_TO_GET_OIDC_TOKEN`: The URL of the local server endpoint to call to retrieve the OIDC token.
   - `$HEADER_KEY` and `$HEADER_VALUE`: The additional header key/value pairs to pass along the GET request to `$URL_TO_GET_OIDC_TOKEN`, e.g. `Metadata-Flavor=Google`.
-  - `$TOKEN_LIFETIME`: The desired lifetime duration of the service account access token in seconds.
-
-  The `service-account-token-lifetime-seconds` flag is optional. If not provided, this defaults to one hour. If a lifetime greater than one hour is required, the service account must be added as an allowed value in an Organization Policy that enforces the `constraints/iam.allowServiceAccountCredentialLifetimeExtension` constraint.
-
+  
   #### Using Executable-sourced credentials with OIDC and SAML
   
   **Executable-sourced credentials**
@@ -522,8 +502,6 @@ body: |-
       # Optional argument for the absolute path to the executable output file.
       # See below on how this argument impacts the library behaviour.
       # --executable-output-file=$EXECUTABLE_OUTPUT_FILE \
-      # Optional argument for specifying the duration of the service account access token.
-      # --service-account-token-lifetime-seconds $TOKEN_LIFETIME \
       --output-file /path/to/generated/config.json
   ```
   Where the following variables need to be substituted:
@@ -533,7 +511,6 @@ body: |-
   - `$SERVICE_ACCOUNT_EMAIL`: The email of the service account to impersonate.
   - `$SUBJECT_TOKEN_TYPE`: The subject token type.
   - `$EXECUTABLE_COMMAND`: The full command to run, including arguments. Must be an absolute path to the program.
-  - `$TOKEN_LIFETIME`: The desired lifetime duration of the service account access token in seconds.
   
   The `--executable-timeout-millis` flag is optional. This is the duration for which
   the auth library will wait for the executable to finish, in milliseconds.
@@ -549,8 +526,6 @@ body: |-
   handle writing to this file - the auth libraries will only attempt to read from
   this location. The format of contents in the file should match the JSON format
   expected by the executable shown below.
-  
-  The `service-account-token-lifetime-seconds` flag is optional. If not provided, this defaults to one hour. If a lifetime greater than one hour is required, the service account must be added as an allowed value in an Organization Policy that enforces the `constraints/iam.allowServiceAccountCredentialLifetimeExtension` constraint.
   
   To retrieve the 3rd party token, the library will call the executable
   using the command specified. The executable's output must adhere to the response format
@@ -631,6 +606,34 @@ body: |-
   
   You can now [use the Auth library](#using-external-identities) to call Google Cloud
   resources from an OIDC or SAML provider.
+  
+  #### Configurable Token Lifetime
+  When creating a credential configuration with workload identity federation using service account impersonation, you can provide an optional argument to configure the access token lifetime.
+  
+  To generate the configuration with configurable token lifetime, run the following command (This example uses an AWS configuration, but the token lifetime can be configured for all workload identity federation providers):
+
+  ```bash
+  # Generate an AWS configuration file with configurable token lifetime.
+  gcloud iam workload-identity-pools create-cred-config \
+      projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$POOL_ID/providers/$AWS_PROVIDER_ID \
+      --service-account $SERVICE_ACCOUNT_EMAIL \
+      --aws \
+      --output-file /path/to/generated/config.json \
+      --service-account-token-lifetime-seconds $TOKEN_LIFETIME
+  ```
+  
+   Where the following variables need to be substituted:
+  - `$PROJECT_NUMBER`: The Google Cloud project number.
+  - `$POOL_ID`: The workload identity pool ID.
+  - `$AWS_PROVIDER_ID`: The AWS provider ID.
+  - `$SERVICE_ACCOUNT_EMAIL`: The email of the service account to impersonate.
+  - `$TOKEN_LIFETIME`: The desired lifetime duration of the service account access token in seconds.
+  
+  The `service-account-token-lifetime-seconds` flag is optional. If not provided, this defaults to one hour.
+  The minimum allowed value is 600 (10 minutes) and the maximum allowed value is 43200 (12 hours).
+  If a lifetime greater than one hour is required, the service account must be added as an allowed value in an Organization Policy that enforces the `constraints/iam.allowServiceAccountCredentialLifetimeExtension` constraint.
+  Note that configuring a short lifetime (e.g. 10 minutes) will result in the library initiating the entire token exchange flow every 10 minutes, which will call the 3rd party token provider even if the 3rd party token is not expired.
+  
   
   ### Using External Identities
 

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -359,7 +359,7 @@ body: |-
   - `$POOL_ID`: The workload identity pool ID.
   - `$AWS_PROVIDER_ID`: The AWS provider ID.
   - `$SERVICE_ACCOUNT_EMAIL`: The email of the service account to impersonate.
-  
+
   This will generate the configuration file in the specified output file.
 
   If you want to use the AWS IMDSv2 flow, you can add the field below to the credential_source in your AWS ADC configuration file:
@@ -398,7 +398,7 @@ body: |-
   - `$POOL_ID`: The workload identity pool ID.
   - `$AZURE_PROVIDER_ID`: The Azure provider ID.
   - `$SERVICE_ACCOUNT_EMAIL`: The email of the service account to impersonate.
-  
+
   This will generate the configuration file in the specified output file.
 
   You can now [start using the Auth library](#using-external-identities) to call Google Cloud resources from Azure.
@@ -444,7 +444,7 @@ body: |-
   - `$OIDC_PROVIDER_ID`: The OIDC provider ID.
   - `$SERVICE_ACCOUNT_EMAIL`: The email of the service account to impersonate.
   - `$PATH_TO_OIDC_ID_TOKEN`: The file path where the OIDC token will be retrieved from.
-  
+
   This will generate the configuration file in the specified output file.
 
   **URL-sourced credentials**
@@ -475,7 +475,7 @@ body: |-
   - `$SERVICE_ACCOUNT_EMAIL`: The email of the service account to impersonate.
   - `$URL_TO_GET_OIDC_TOKEN`: The URL of the local server endpoint to call to retrieve the OIDC token.
   - `$HEADER_KEY` and `$HEADER_VALUE`: The additional header key/value pairs to pass along the GET request to `$URL_TO_GET_OIDC_TOKEN`, e.g. `Metadata-Flavor=Google`.
-  
+
   #### Using Executable-sourced credentials with OIDC and SAML
   
   **Executable-sourced credentials**

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -351,6 +351,8 @@ body: |-
       projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$POOL_ID/providers/$AWS_PROVIDER_ID \
       --service-account $SERVICE_ACCOUNT_EMAIL \
       --aws \
+      # Optional argument for specifying the duration of the service account access token.
+      # --service-account-token-lifetime-seconds $TOKEN_LIFETIME \
       --output-file /path/to/generated/config.json
   ```
 
@@ -359,8 +361,11 @@ body: |-
   - `$POOL_ID`: The workload identity pool ID.
   - `$AWS_PROVIDER_ID`: The AWS provider ID.
   - `$SERVICE_ACCOUNT_EMAIL`: The email of the service account to impersonate.
-
+  - `$TOKEN_LIFETIME`: The desired lifetime duration of the service account access token in seconds.
+  
   This will generate the configuration file in the specified output file.
+
+  The `service-account-token-lifetime-seconds` flag is optional. If not provided, this defaults to one hour. If a lifetime greater than one hour is required, the service account must be added as an allowed value in an Organization Policy that enforces the `constraints/iam.allowServiceAccountCredentialLifetimeExtension` constraint.
 
   If you want to use the AWS IMDSv2 flow, you can add the field below to the credential_source in your AWS ADC configuration file:
   "imdsv2_session_token_url": "http://169.254.169.254/latest/api/token"
@@ -390,6 +395,8 @@ body: |-
       projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$POOL_ID/providers/$AZURE_PROVIDER_ID \
       --service-account $SERVICE_ACCOUNT_EMAIL \
       --azure \
+      # Optional argument for specifying the duration of the service account access token.
+      # --service-account-token-lifetime-seconds $TOKEN_LIFETIME \
       --output-file /path/to/generated/config.json
   ```
 
@@ -398,8 +405,11 @@ body: |-
   - `$POOL_ID`: The workload identity pool ID.
   - `$AZURE_PROVIDER_ID`: The Azure provider ID.
   - `$SERVICE_ACCOUNT_EMAIL`: The email of the service account to impersonate.
-
+  - `$TOKEN_LIFETIME`: The desired lifetime duration of the service account access token in seconds.
+  
   This will generate the configuration file in the specified output file.
+
+  The `service-account-token-lifetime-seconds` flag is optional. If not provided, this defaults to one hour. If a lifetime greater than one hour is required, the service account must be added as an allowed value in an Organization Policy that enforces the `constraints/iam.allowServiceAccountCredentialLifetimeExtension` constraint.
 
   You can now [start using the Auth library](#using-external-identities) to call Google Cloud resources from Azure.
 
@@ -435,6 +445,8 @@ body: |-
       # Optional argument for the field that contains the OIDC credential.
       # This is required for json.
       # --credential-source-field-name "id_token" \
+      # Optional argument for specifying the duration of the service account access token.
+      # --service-account-token-lifetime-seconds $TOKEN_LIFETIME \
       --output-file /path/to/generated/config.json
   ```
 
@@ -444,8 +456,11 @@ body: |-
   - `$OIDC_PROVIDER_ID`: The OIDC provider ID.
   - `$SERVICE_ACCOUNT_EMAIL`: The email of the service account to impersonate.
   - `$PATH_TO_OIDC_ID_TOKEN`: The file path where the OIDC token will be retrieved from.
-
+  - `$TOKEN_LIFETIME`: The desired lifetime duration of the service account access token in seconds.
+  
   This will generate the configuration file in the specified output file.
+
+  The `service-account-token-lifetime-seconds` flag is optional. If not provided, this defaults to one hour. If a lifetime greater than one hour is required, the service account must be added as an allowed value in an Organization Policy that enforces the `constraints/iam.allowServiceAccountCredentialLifetimeExtension` constraint.
 
   **URL-sourced credentials**
   For URL-sourced credentials, a local server needs to host a GET endpoint to return the OIDC token. The response can be in plain text or JSON.
@@ -465,6 +480,8 @@ body: |-
       # Optional argument for the field that contains the OIDC credential.
       # This is required for json.
       # --credential-source-field-name "id_token" \
+      # Optional argument for specifying the duration of the service account access token.
+      # --service-account-token-lifetime-seconds $TOKEN_LIFETIME \
       --output-file /path/to/generated/config.json
   ```
 
@@ -475,6 +492,9 @@ body: |-
   - `$SERVICE_ACCOUNT_EMAIL`: The email of the service account to impersonate.
   - `$URL_TO_GET_OIDC_TOKEN`: The URL of the local server endpoint to call to retrieve the OIDC token.
   - `$HEADER_KEY` and `$HEADER_VALUE`: The additional header key/value pairs to pass along the GET request to `$URL_TO_GET_OIDC_TOKEN`, e.g. `Metadata-Flavor=Google`.
+  - `$TOKEN_LIFETIME`: The desired lifetime duration of the service account access token in seconds.
+
+  The `service-account-token-lifetime-seconds` flag is optional. If not provided, this defaults to one hour. If a lifetime greater than one hour is required, the service account must be added as an allowed value in an Organization Policy that enforces the `constraints/iam.allowServiceAccountCredentialLifetimeExtension` constraint.
 
   #### Using Executable-sourced credentials with OIDC and SAML
   
@@ -502,6 +522,8 @@ body: |-
       # Optional argument for the absolute path to the executable output file.
       # See below on how this argument impacts the library behaviour.
       # --executable-output-file=$EXECUTABLE_OUTPUT_FILE \
+      # Optional argument for specifying the duration of the service account access token.
+      # --service-account-token-lifetime-seconds $TOKEN_LIFETIME \
       --output-file /path/to/generated/config.json
   ```
   Where the following variables need to be substituted:
@@ -511,6 +533,7 @@ body: |-
   - `$SERVICE_ACCOUNT_EMAIL`: The email of the service account to impersonate.
   - `$SUBJECT_TOKEN_TYPE`: The subject token type.
   - `$EXECUTABLE_COMMAND`: The full command to run, including arguments. Must be an absolute path to the program.
+  - `$TOKEN_LIFETIME`: The desired lifetime duration of the service account access token in seconds.
   
   The `--executable-timeout-millis` flag is optional. This is the duration for which
   the auth library will wait for the executable to finish, in milliseconds.
@@ -526,6 +549,8 @@ body: |-
   handle writing to this file - the auth libraries will only attempt to read from
   this location. The format of contents in the file should match the JSON format
   expected by the executable shown below.
+  
+  The `service-account-token-lifetime-seconds` flag is optional. If not provided, this defaults to one hour. If a lifetime greater than one hour is required, the service account must be added as an allowed value in an Organization Policy that enforces the `constraints/iam.allowServiceAccountCredentialLifetimeExtension` constraint.
   
   To retrieve the 3rd party token, the library will call the executable
   using the command specified. The executable's output must adhere to the response format

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -608,9 +608,9 @@ body: |-
   resources from an OIDC or SAML provider.
   
   #### Configurable Token Lifetime
-  When creating a credential configuration with workload identity federation using service account impersonation, you can provide an optional argument to configure the access token lifetime.
+  When creating a credential configuration with workload identity federation using service account impersonation, you can provide an optional argument to configure the service account access token lifetime.
   
-  To generate the configuration with configurable token lifetime, run the following command (This example uses an AWS configuration, but the token lifetime can be configured for all workload identity federation providers):
+  To generate the configuration with configurable token lifetime, run the following command (this example uses an AWS configuration, but the token lifetime can be configured for all workload identity federation providers):
 
   ```bash
   # Generate an AWS configuration file with configurable token lifetime.
@@ -632,9 +632,9 @@ body: |-
   The `service-account-token-lifetime-seconds` flag is optional. If not provided, this defaults to one hour.
   The minimum allowed value is 600 (10 minutes) and the maximum allowed value is 43200 (12 hours).
   If a lifetime greater than one hour is required, the service account must be added as an allowed value in an Organization Policy that enforces the `constraints/iam.allowServiceAccountCredentialLifetimeExtension` constraint.
+
   Note that configuring a short lifetime (e.g. 10 minutes) will result in the library initiating the entire token exchange flow every 10 minutes, which will call the 3rd party token provider even if the 3rd party token is not expired.
-  
-  
+
   ### Using External Identities
 
   External identities (AWS, Azure and OIDC-based providers) can be used with `Application Default Credentials`.

--- a/README.md
+++ b/README.md
@@ -651,6 +651,34 @@ credentials unless they do not meet your specific requirements.
 You can now [use the Auth library](#using-external-identities) to call Google Cloud
 resources from an OIDC or SAML provider.
 
+#### Configurable Token Lifetime
+When creating a credential configuration with workload identity federation using service account impersonation, you can provide an optional argument to configure the service account access token lifetime.
+
+To generate the configuration with configurable token lifetime, run the following command (this example uses an AWS configuration, but the token lifetime can be configured for all workload identity federation providers):
+
+```bash
+# Generate an AWS configuration file with configurable token lifetime.
+gcloud iam workload-identity-pools create-cred-config \
+    projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$POOL_ID/providers/$AWS_PROVIDER_ID \
+    --service-account $SERVICE_ACCOUNT_EMAIL \
+    --aws \
+    --output-file /path/to/generated/config.json \
+    --service-account-token-lifetime-seconds $TOKEN_LIFETIME
+```
+
+ Where the following variables need to be substituted:
+- `$PROJECT_NUMBER`: The Google Cloud project number.
+- `$POOL_ID`: The workload identity pool ID.
+- `$AWS_PROVIDER_ID`: The AWS provider ID.
+- `$SERVICE_ACCOUNT_EMAIL`: The email of the service account to impersonate.
+- `$TOKEN_LIFETIME`: The desired lifetime duration of the service account access token in seconds.
+
+The `service-account-token-lifetime-seconds` flag is optional. If not provided, this defaults to one hour.
+The minimum allowed value is 600 (10 minutes) and the maximum allowed value is 43200 (12 hours).
+If a lifetime greater than one hour is required, the service account must be added as an allowed value in an Organization Policy that enforces the `constraints/iam.allowServiceAccountCredentialLifetimeExtension` constraint.
+
+Note that configuring a short lifetime (e.g. 10 minutes) will result in the library initiating the entire token exchange flow every 10 minutes, which will call the 3rd party token provider even if the 3rd party token is not expired.
+
 ### Using External Identities
 
 External identities (AWS, Azure and OIDC-based providers) can be used with `Application Default Credentials`.

--- a/src/auth/baseexternalclient.ts
+++ b/src/auth/baseexternalclient.ts
@@ -41,6 +41,8 @@ const DEFAULT_OAUTH_SCOPE = 'https://www.googleapis.com/auth/cloud-platform';
 const GOOGLE_APIS_DOMAIN_PATTERN = '\\.googleapis\\.com$';
 /** The variable portion pattern in a Google APIs domain. */
 const VARIABLE_PORTION_PATTERN = '[^\\.\\s\\/\\\\]+';
+/** Default impersonated token lifespan in seconds.*/
+const DEFAULT_TOKEN_LIFESPAN = 3600;
 
 /**
  * Offset to take into account network delays and server clock skews.
@@ -69,6 +71,9 @@ export interface BaseExternalAccountClientOptions {
   audience: string;
   subject_token_type: string;
   service_account_impersonation_url?: string;
+  service_account_impersonation?: {
+    token_lifetime_seconds?: number;
+  };
   token_url: string;
   token_info_url?: string;
   client_id?: string;
@@ -130,6 +135,7 @@ export abstract class BaseExternalAccountClient extends AuthClient {
   protected readonly audience: string;
   protected readonly subjectTokenType: string;
   private readonly serviceAccountImpersonationUrl?: string;
+  private readonly serviceAccountImpersonationLifetime?: number;
   private readonly stsCredential: sts.StsCredentials;
   private readonly clientAuth?: ClientAuthentication;
   private readonly workforcePoolUserProject?: string;
@@ -203,6 +209,8 @@ export abstract class BaseExternalAccountClient extends AuthClient {
     }
     this.serviceAccountImpersonationUrl =
       options.service_account_impersonation_url;
+    this.serviceAccountImpersonationLifetime =
+      options.service_account_impersonation?.token_lifetime_seconds ?? DEFAULT_TOKEN_LIFESPAN;
     // As threshold could be zero,
     // eagerRefreshThresholdMillis || EXPIRATION_TIME_OFFSET will override the
     // zero value.
@@ -510,6 +518,7 @@ export abstract class BaseExternalAccountClient extends AuthClient {
       },
       data: {
         scope: this.getScopesArray(),
+        lifetime: this.serviceAccountImpersonationLifetime + 's',
       },
       responseType: 'json',
     };

--- a/src/auth/baseexternalclient.ts
+++ b/src/auth/baseexternalclient.ts
@@ -210,7 +210,8 @@ export abstract class BaseExternalAccountClient extends AuthClient {
     this.serviceAccountImpersonationUrl =
       options.service_account_impersonation_url;
     this.serviceAccountImpersonationLifetime =
-      options.service_account_impersonation?.token_lifetime_seconds ?? DEFAULT_TOKEN_LIFESPAN;
+      options.service_account_impersonation?.token_lifetime_seconds ??
+      DEFAULT_TOKEN_LIFESPAN;
     // As threshold could be zero,
     // eagerRefreshThresholdMillis || EXPIRATION_TIME_OFFSET will override the
     // zero value.

--- a/test/externalclienthelper.ts
+++ b/test/externalclienthelper.ts
@@ -44,8 +44,10 @@ interface NockMockGenerateAccessToken {
   token: string;
   response: IamGenerateAccessTokenResponse | CloudRequestError;
   scopes: string[];
+  lifetime?: number;
 }
 
+const defaultLifetime = 3600;
 const defaultProjectNumber = '123456';
 const poolId = 'POOL_ID';
 const providerId = 'PROVIDER_ID';
@@ -86,6 +88,8 @@ export function mockGenerateAccessToken(
         saPath,
         {
           scope: nockMockGenerateAccessToken.scopes,
+          lifetime:
+            (nockMockGenerateAccessToken.lifetime ?? defaultLifetime) + 's',
         },
         {
           reqheaders: {


### PR DESCRIPTION
Adds support for configurable token lifespan via the service_account_impersonation object in the ADC. Also adds unit + integration tests.
See go/byoid-sdk-service-account-impersonation-ctl