### PR TITLE
fix: do not use #private

### DIFF
--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -206,7 +206,7 @@ export class GoogleAuth<T extends AuthClient = JSONClient> {
    *
    * @returns Promise that resolves with project id (or `null`)
    */
-  async #getProjectIdOptional(): Promise<string | null> {
+  private async getProjectIdOptional(): Promise<string | null> {
     try {
       return await this.getProjectId();
     } catch (e) {
@@ -232,7 +232,7 @@ export class GoogleAuth<T extends AuthClient = JSONClient> {
    *
    * @returns projectId
    */
-  async #findAndCacheProjectId(): Promise<string> {
+  private async findAndCacheProjectId(): Promise<string> {
     let projectId: string | null | undefined = null;
 
     projectId ||= await this.getProductionProjectId();
@@ -255,7 +255,7 @@ export class GoogleAuth<T extends AuthClient = JSONClient> {
     }
 
     if (!this._findProjectIdPromise) {
-      this._findProjectIdPromise = this.#findAndCacheProjectId();
+      this._findProjectIdPromise = this.findAndCacheProjectId();
     }
     return this._findProjectIdPromise;
   }
@@ -305,7 +305,7 @@ export class GoogleAuth<T extends AuthClient = JSONClient> {
     if (this.cachedCredential) {
       return {
         credential: this.cachedCredential,
-        projectId: await this.#getProjectIdOptional(),
+        projectId: await this.getProjectIdOptional(),
       };
     }
 
@@ -323,7 +323,7 @@ export class GoogleAuth<T extends AuthClient = JSONClient> {
         credential.scopes = this.getAnyScopes();
       }
       this.cachedCredential = credential;
-      projectId = await this.#getProjectIdOptional();
+      projectId = await this.getProjectIdOptional();
 
       return {credential, projectId};
     }
@@ -339,7 +339,7 @@ export class GoogleAuth<T extends AuthClient = JSONClient> {
         credential.scopes = this.getAnyScopes();
       }
       this.cachedCredential = credential;
-      projectId = await this.#getProjectIdOptional();
+      projectId = await this.getProjectIdOptional();
       return {credential, projectId};
     }
 
@@ -366,7 +366,7 @@ export class GoogleAuth<T extends AuthClient = JSONClient> {
     // the rest.
     (options as ComputeOptions).scopes = this.getAnyScopes();
     this.cachedCredential = new Compute(options);
-    projectId = await this.#getProjectIdOptional();
+    projectId = await this.getProjectIdOptional();
     return {projectId, credential: this.cachedCredential};
   }
 


### PR DESCRIPTION
Adding a `#` private method is technically a breaking change. Our packing tests across all client libraries are now failing with

```
node_modules/google-auth-library/build/src/auth/googleauth.d.ts:67:5 - error TS18028: Private identifiers are only available when targeting ECMAScript 2015 and higher.

67     #private;
       ~~~~~~~~
```

(in CI, this looks like a `pack-n-play` TypeScript test failure as a part of system tests)

Let's not be that modern and use the regular private method instead.