### PR TITLE
feat: adding validation for psc endpoints

### DIFF
--- a/src/auth/baseexternalclient.ts
+++ b/src/auth/baseexternalclient.ts
@@ -606,6 +606,14 @@ export abstract class BaseExternalAccountClient extends AuthClient {
           apiName +
           GOOGLE_APIS_DOMAIN_PATTERN
       ),
+      new RegExp(
+        '^' +
+          apiName +
+          '\\-' +
+          VARIABLE_PORTION_PATTERN +
+          '\\.p' +
+          GOOGLE_APIS_DOMAIN_PATTERN
+      ),
     ];
     for (const googleAPIsDomainPattern of googleAPIsDomainPatterns) {
       if (urlDomain.match(googleAPIsDomainPattern)) {

--- a/test/test.baseexternalclient.ts
+++ b/test/test.baseexternalclient.ts
@@ -182,6 +182,9 @@ describe('BaseExternalAccountClient', () => {
       'http://sts.p.googleapis.com',
       'https://xyz-sts.p.googleapis.com',
       'https://sts-xyz.123.p.googleapis.com',
+      'https://sts-xyz.p1.googleapis.com',
+      'https://sts-xyz.p.foo.com',
+      'https://sts-xyz.p.foo.googleapis.com',
     ];
     invalidTokenUrls.forEach(invalidTokenUrl => {
       it(`should throw on invalid token url: ${invalidTokenUrl}`, () => {
@@ -242,6 +245,9 @@ describe('BaseExternalAccountClient', () => {
       'http://iamcredentials.p.googleapis.com',
       'https://xyz-iamcredentials.p.googleapis.com',
       'https://iamcredentials-xyz.123.p.googleapis.com',
+      'https://iamcredentials-xyz.p1.googleapis.com',
+      'https://iamcredentials-xyz.p.foo.com',
+      'https://iamcredentials-xyz.p.foo.googleapis.com',
     ];
     invalidServiceAccountImpersonationUrls.forEach(
       invalidServiceAccountImpersonationUrl => {

--- a/test/test.baseexternalclient.ts
+++ b/test/test.baseexternalclient.ts
@@ -176,6 +176,12 @@ describe('BaseExternalAccountClient', () => {
       'https://us-east- 1.sts.googleapis.com',
       'https://us/.east/.1.sts.googleapis.com',
       'https://us.ea\\st.1.sts.googleapis.com',
+      'https://sts.pgoogleapis.com',
+      'https://p.googleapis.com',
+      'https://sts.p.com',
+      'http://sts.p.googleapis.com',
+      'https://xyz-sts.p.googleapis.com',
+      'https://sts-xyz.123.p.googleapis.com'
     ];
     invalidTokenUrls.forEach(invalidTokenUrl => {
       it(`should throw on invalid token url: ${invalidTokenUrl}`, () => {
@@ -200,6 +206,9 @@ describe('BaseExternalAccountClient', () => {
         'https://us-west-1-sts.googleapis.com',
         'https://exmaple.sts.googleapis.com',
         'https://example-sts.googleapis.com',
+        'https://sts-xyz123.p.googleapis.com',
+        'https://sts-xyz-123.p.googleapis.com',
+        'https://sts-xys123.p.googleapis.com/path/to/example',
       ];
       const validOptions = Object.assign({}, externalAccountOptions);
       for (const validTokenUrl of validTokenUrls) {
@@ -227,6 +236,12 @@ describe('BaseExternalAccountClient', () => {
       'https://us-east- 1.iamcredentials.googleapis.com',
       'https://us/.east/.1.iamcredentials.googleapis.com',
       'https://us.ea\\st.1.iamcredentials.googleapis.com',
+      'https://iamcredentials.pgoogleapis.com',
+      'https://p.googleapis.com',
+      'https://iamcredentials.p.com',
+      'http://iamcredentials.p.googleapis.com',
+      'https://xyz-iamcredentials.p.googleapis.com',
+      'https://iamcredentials-xyz.123.p.googleapis.com',
     ];
     invalidServiceAccountImpersonationUrls.forEach(
       invalidServiceAccountImpersonationUrl => {
@@ -258,6 +273,9 @@ describe('BaseExternalAccountClient', () => {
         'https://us-west-1-iamcredentials.googleapis.com',
         'https://example.iamcredentials.googleapis.com',
         'https://example-iamcredentials.googleapis.com',
+        'https://iamcredentials-xyz123.p.googleapis.com',
+        'https://iamcredentials-xyz-123.p.googleapis.com',
+        'https://iamcredentials-xys123.p.googleapis.com/path/to/example',
       ];
       const validOptions = Object.assign({}, externalAccountOptionsWithSA);
       for (const validServiceAccountImpersonationUrl of validServiceAccountImpersonationUrls) {

--- a/test/test.baseexternalclient.ts
+++ b/test/test.baseexternalclient.ts
@@ -181,7 +181,7 @@ describe('BaseExternalAccountClient', () => {
       'https://sts.p.com',
       'http://sts.p.googleapis.com',
       'https://xyz-sts.p.googleapis.com',
-      'https://sts-xyz.123.p.googleapis.com'
+      'https://sts-xyz.123.p.googleapis.com',
     ];
     invalidTokenUrls.forEach(invalidTokenUrl => {
       it(`should throw on invalid token url: ${invalidTokenUrl}`, () => {


### PR DESCRIPTION
Adding validation for PSC endpoints for google apis:

sts-*.p.googleapis.com

iamcredentials-*.p.googleapis.com