### PR TITLE
fix: Validate url domain for aws metadata urls

### DIFF
--- a/src/auth/awsclient.ts
+++ b/src/auth/awsclient.ts
@@ -121,7 +121,7 @@ export class AwsClient extends BaseExternalAccountClient {
     urlString: string | undefined,
     nameOfData: string
   ) {
-    if (typeof urlString !== 'undefined') {
+    if (urlString !== undefined) {
       const url = new URL(urlString);
 
       if (url.host !== '169.254.169.254' && url.host !== '[fd00:ec2::254]') {

--- a/src/auth/awsclient.ts
+++ b/src/auth/awsclient.ts
@@ -88,19 +88,14 @@ export class AwsClient extends BaseExternalAccountClient {
     // This is only required if the AWS region is not available in the
     // AWS_REGION or AWS_DEFAULT_REGION environment variables.
     this.regionUrl = options.credential_source.region_url;
-    this.validateMetadataServerUrlIfAny(this.regionUrl, 'region_url');
     // This is only required if AWS security credentials are not available in
     // environment variables.
     this.securityCredentialsUrl = options.credential_source.url;
-    this.validateMetadataServerUrlIfAny(this.securityCredentialsUrl, 'url');
     this.regionalCredVerificationUrl =
       options.credential_source.regional_cred_verification_url;
     this.imdsV2SessionTokenUrl =
       options.credential_source.imdsv2_session_token_url;
-    this.validateMetadataServerUrlIfAny(
-      this.imdsV2SessionTokenUrl,
-      'imdsv2_session_token_url'
-    );
+    this.validateMetadataServerUrls();
     const match = this.environmentId?.match(/^(aws)(\d+)$/);
     if (!match || !this.regionalCredVerificationUrl) {
       throw new Error('No valid AWS "credential_source" provided');
@@ -113,14 +108,23 @@ export class AwsClient extends BaseExternalAccountClient {
     this.region = '';
   }
 
-  validateMetadataServerUrlIfAny(
+  private validateMetadataServerUrls() {
+    this.validateMetadataServerUrlIfAny(this.regionUrl, 'region_url');
+    this.validateMetadataServerUrlIfAny(this.securityCredentialsUrl, 'url');
+    this.validateMetadataServerUrlIfAny(
+      this.imdsV2SessionTokenUrl,
+      'imdsv2_session_token_url'
+    );
+  }
+
+  private validateMetadataServerUrlIfAny(
     urlString: string | undefined,
     nameOfData: string
   ) {
     if (typeof urlString !== 'undefined') {
       const url = new URL(urlString);
 
-      if (url.host !== '169.254.169.254' && url.host !== 'fd00:ec2::254') {
+      if (url.host !== '169.254.169.254' && url.host !== '[fd00:ec2::254]') {
         throw new Error(`Invalid host "${url.host}" for "${nameOfData}"`);
       }
     }

--- a/src/auth/awsclient.ts
+++ b/src/auth/awsclient.ts
@@ -88,16 +88,19 @@ export class AwsClient extends BaseExternalAccountClient {
     // This is only required if the AWS region is not available in the
     // AWS_REGION or AWS_DEFAULT_REGION environment variables.
     this.regionUrl = options.credential_source.region_url;
-    this.validateMetadataServerUrlIfAny(this.regionUrl, "region_url");
+    this.validateMetadataServerUrlIfAny(this.regionUrl, 'region_url');
     // This is only required if AWS security credentials are not available in
     // environment variables.
     this.securityCredentialsUrl = options.credential_source.url;
-    this.validateMetadataServerUrlIfAny(this.securityCredentialsUrl, "url");
+    this.validateMetadataServerUrlIfAny(this.securityCredentialsUrl, 'url');
     this.regionalCredVerificationUrl =
       options.credential_source.regional_cred_verification_url;
     this.imdsV2SessionTokenUrl =
       options.credential_source.imdsv2_session_token_url;
-    this.validateMetadataServerUrlIfAny(this.imdsV2SessionTokenUrl, "imdsv2_session_token_url");
+    this.validateMetadataServerUrlIfAny(
+      this.imdsV2SessionTokenUrl,
+      'imdsv2_session_token_url'
+    );
     const match = this.environmentId?.match(/^(aws)(\d+)$/);
     if (!match || !this.regionalCredVerificationUrl) {
       throw new Error('No valid AWS "credential_source" provided');
@@ -110,14 +113,14 @@ export class AwsClient extends BaseExternalAccountClient {
     this.region = '';
   }
 
-  validateMetadataServerUrlIfAny(urlString: string | undefined, nameOfData: string)
-  {
-    if (typeof urlString != 'undefined')
-    {
+  validateMetadataServerUrlIfAny(
+    urlString: string | undefined,
+    nameOfData: string
+  ) {
+    if (typeof urlString !== 'undefined') {
       const url = new URL(urlString);
 
-      if (url.host !== '169.254.169.254' && url.host !== 'fd00:ec2::254')
-      {
+      if (url.host !== '169.254.169.254' && url.host !== 'fd00:ec2::254') {
         throw new Error(`Invalid host "${url.host}" for "${nameOfData}"`);
       }
     }

--- a/src/auth/awsclient.ts
+++ b/src/auth/awsclient.ts
@@ -88,13 +88,16 @@ export class AwsClient extends BaseExternalAccountClient {
     // This is only required if the AWS region is not available in the
     // AWS_REGION or AWS_DEFAULT_REGION environment variables.
     this.regionUrl = options.credential_source.region_url;
+    this.validateMetadataServerUrlIfAny(this.regionUrl, "region_url");
     // This is only required if AWS security credentials are not available in
     // environment variables.
     this.securityCredentialsUrl = options.credential_source.url;
+    this.validateMetadataServerUrlIfAny(this.securityCredentialsUrl, "url");
     this.regionalCredVerificationUrl =
       options.credential_source.regional_cred_verification_url;
     this.imdsV2SessionTokenUrl =
       options.credential_source.imdsv2_session_token_url;
+    this.validateMetadataServerUrlIfAny(this.imdsV2SessionTokenUrl, "imdsv2_session_token_url");
     const match = this.environmentId?.match(/^(aws)(\d+)$/);
     if (!match || !this.regionalCredVerificationUrl) {
       throw new Error('No valid AWS "credential_source" provided');
@@ -105,6 +108,19 @@ export class AwsClient extends BaseExternalAccountClient {
     }
     this.awsRequestSigner = null;
     this.region = '';
+  }
+
+  validateMetadataServerUrlIfAny(urlString: string | undefined, nameOfData: string)
+  {
+    if (typeof urlString != 'undefined')
+    {
+      const url = new URL(urlString);
+
+      if (url.host !== '169.254.169.254' && url.host !== 'fd00:ec2::254')
+      {
+        throw new Error(`Invalid host "${url.host}" for "${nameOfData}"`);
+      }
+    }
   }
 
   /**

--- a/test/test.awsclient.ts
+++ b/test/test.awsclient.ts
@@ -203,6 +203,64 @@ describe('AwsClient', () => {
       });
     });
 
+    it('should throw when an unsupported url is provided', () => {
+      const expectedError = new Error(
+        'Invalid host "baddomain.com" for "url"'
+      );
+      const invalidCredentialSource = Object.assign({}, awsCredentialSource);
+      invalidCredentialSource.url = 'http://baddomain.com/fake';
+      const invalidOptions = {
+        type: 'external_account',
+        audience,
+        subject_token_type: 'urn:ietf:params:aws:token-type:aws4_request',
+        token_url: getTokenUrl(),
+        credential_source: invalidCredentialSource,
+      };
+
+      assert.throws(() => {
+        return new AwsClient(invalidOptions);
+      }, expectedError);
+    });
+
+    it('should throw when an unsupported imdsv2_session_token_url is provided', () => {
+      const expectedError = new Error(
+        'Invalid host "baddomain.com" for "imdsv2_session_token_url"'
+      );
+      const invalidCredentialSource = Object.assign(
+        {imdsv2_session_token_url: 'http://baddomain.com/fake'},
+        awsCredentialSource);
+      const invalidOptions = {
+        type: 'external_account',
+        audience,
+        subject_token_type: 'urn:ietf:params:aws:token-type:aws4_request',
+        token_url: getTokenUrl(),
+        credential_source: invalidCredentialSource,
+      };
+
+      assert.throws(() => {
+        return new AwsClient(invalidOptions);
+      }, expectedError);
+    });
+
+    it('should throw when an unsupported region_url is provided', () => {
+      const expectedError = new Error(
+        'Invalid host "baddomain.com" for "region_url"'
+      );
+      const invalidCredentialSource = Object.assign({}, awsCredentialSource);
+      invalidCredentialSource.region_url = 'http://baddomain.com/fake';
+      const invalidOptions = {
+        type: 'external_account',
+        audience,
+        subject_token_type: 'urn:ietf:params:aws:token-type:aws4_request',
+        token_url: getTokenUrl(),
+        credential_source: invalidCredentialSource,
+      };
+
+      assert.throws(() => {
+        return new AwsClient(invalidOptions);
+      }, expectedError);
+    });
+
     it('should throw when an unsupported environment ID is provided', () => {
       const expectedError = new Error(
         'No valid AWS "credential_source" provided'

--- a/test/test.awsclient.ts
+++ b/test/test.awsclient.ts
@@ -204,9 +204,7 @@ describe('AwsClient', () => {
     });
 
     it('should throw when an unsupported url is provided', () => {
-      const expectedError = new Error(
-        'Invalid host "baddomain.com" for "url"'
-      );
+      const expectedError = new Error('Invalid host "baddomain.com" for "url"');
       const invalidCredentialSource = Object.assign({}, awsCredentialSource);
       invalidCredentialSource.url = 'http://baddomain.com/fake';
       const invalidOptions = {
@@ -228,7 +226,8 @@ describe('AwsClient', () => {
       );
       const invalidCredentialSource = Object.assign(
         {imdsv2_session_token_url: 'http://baddomain.com/fake'},
-        awsCredentialSource);
+        awsCredentialSource
+      );
       const invalidOptions = {
         type: 'external_account',
         audience,


### PR DESCRIPTION
Updating AWS credential source validation as per new updates in [AIP](https://github.com/aip-dev/google.aip.dev/pull/959). Make sure the host of url, region_url and imdsv2 session token url belong to AWS metadata server.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-auth-library-nodejs/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
