### PR TITLE
feat: add api key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ npm install google-auth-library
 ## Ways to authenticate
 This library provides a variety of ways to authenticate to your Google services.
 - [Application Default Credentials](#choosing-the-correct-credential-type-automatically) - Use Application Default Credentials when you use a single identity for all users in your application. Especially useful for applications running on Google Cloud. Application Default Credentials also support workload identity federation to access Google Cloud resources from non-Google Cloud platforms.
+- [API key](#api-key) - An [API key](https://cloud.google.com/docs/authentication/api-keys) is a simple encrypted string that identifies an application without any principal. They are useful for accessing public data anonymously, and are used to associate API requests with your project for quota and billing.
 - [OAuth 2](#oauth2) - Use OAuth2 when you need to perform actions on behalf of the end user.
 - [JSON Web Tokens](#json-web-tokens) - Use JWT when you are using a single identity for all users. Especially useful for server->server or server->API communication.
 - [Google Compute](#compute) - Directly use a service account on Google Cloud Platform. Useful for server->server or server->API communication.
@@ -100,6 +101,29 @@ async function main() {
   const projectId = await auth.getProjectId();
   const url = `https://dns.googleapis.com/dns/v1/projects/${projectId}`;
   const res = await client.request({ url });
+  console.log(res.data);
+}
+
+main().catch(console.error);
+```
+
+## API key
+[API key](https://cloud.google.com/docs/authentication/api-keys) are useful for accessing public data anonymously, and are used to associate API requests with your project for quota and billing. You can follow the instructions on [this page](https://cloud.google.com/docs/authentication/api-keys) to create an API key.
+
+The following example demonstrates how to use API key with the Google Cloud Language API. 
+
+```js
+const {GoogleAuth} = require('google-auth-library');
+
+async function main() {
+  const auth = new GoogleAuth({
+    apiKey: 'fill in the API key'
+  });
+
+  const client = await auth.getClient();
+  const url = `https://language.googleapis.com/v1/documents:analyzeSentiment`;
+  const body = "{'document':{'type':'PLAIN_TEXT','content':'hello world'},'encodingType':'UTF8'}";
+  const res = await client.request({ 'url':url, 'method':'POST', 'body':body });
   console.log(res.data);
 }
 
@@ -1189,6 +1213,7 @@ Samples are in the [`samples/`](https://github.com/googleapis/google-auth-librar
 | Adc | [source code](https://github.com/googleapis/google-auth-library-nodejs/blob/main/samples/adc.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/google-auth-library-nodejs&page=editor&open_in_editor=samples/adc.js,samples/README.md) |
 | Authenticate Explicit | [source code](https://github.com/googleapis/google-auth-library-nodejs/blob/main/samples/authenticateExplicit.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/google-auth-library-nodejs&page=editor&open_in_editor=samples/authenticateExplicit.js,samples/README.md) |
 | Authenticate Implicit With Adc | [source code](https://github.com/googleapis/google-auth-library-nodejs/blob/main/samples/authenticateImplicitWithAdc.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/google-auth-library-nodejs&page=editor&open_in_editor=samples/authenticateImplicitWithAdc.js,samples/README.md) |
+| Api-key | [source code](https://github.com/googleapis/google-auth-library-nodejs/blob/main/samples/api-key.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/google-auth-library-nodejs&page=editor&open_in_editor=samples/api-key.js,samples/README.md) |
 | Compute | [source code](https://github.com/googleapis/google-auth-library-nodejs/blob/main/samples/compute.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/google-auth-library-nodejs&page=editor&open_in_editor=samples/compute.js,samples/README.md) |
 | Credentials | [source code](https://github.com/googleapis/google-auth-library-nodejs/blob/main/samples/credentials.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/google-auth-library-nodejs&page=editor&open_in_editor=samples/credentials.js,samples/README.md) |
 | Downscopedclient | [source code](https://github.com/googleapis/google-auth-library-nodejs/blob/main/samples/downscopedclient.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/google-auth-library-nodejs&page=editor&open_in_editor=samples/downscopedclient.js,samples/README.md) |

--- a/samples/README.md
+++ b/samples/README.md
@@ -15,6 +15,7 @@ This is Google's officially supported [node.js](http://nodejs.org/) client libra
   * [Adc](#adc)
   * [Authenticate Explicit](#authenticate-explicit)
   * [Authenticate Implicit With Adc](#authenticate-implicit-with-adc)
+  * [Api-key](#api-key)
   * [Compute](#compute)
   * [Credentials](#credentials)
   * [Downscopedclient](#downscopedclient)
@@ -93,6 +94,23 @@ __Usage:__
 
 
 `node samples/authenticateImplicitWithAdc.js`
+
+
+-----
+
+
+
+
+### Api-key
+
+View the [source code](https://github.com/googleapis/google-auth-library-nodejs/blob/main/samples/api-key.js).
+
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/google-auth-library-nodejs&page=editor&open_in_editor=samples/api-key.js,samples/README.md)
+
+__Usage:__
+
+
+`node samples/api-key.js`
 
 
 -----

--- a/samples/api-key.js
+++ b/samples/api-key.js
@@ -1,0 +1,38 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Import the GoogleAuth library, and create a new GoogleAuth client.
+ */
+const {GoogleAuth} = require('google-auth-library');
+
+/**
+ * Acquire a client, and make a request to an API that's enabled by default.
+ */
+async function main() {
+  const auth = new GoogleAuth({
+    apiKey: 'fill in the API key',
+  });
+
+  const client = await auth.getClient();
+  const url = 'https://language.googleapis.com/v1/documents:analyzeSentiment';
+  const body =
+    "{'document':{'type':'PLAIN_TEXT','content':'hello world'},'encodingType':'UTF8'}";
+  const res = await client.request({url: url, method: 'POST', body: body});
+  console.log(res.data);
+}
+
+main().catch(console.error);

--- a/samples/api-key.js
+++ b/samples/api-key.js
@@ -12,27 +12,44 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-'use strict';
-
 /**
- * Import the GoogleAuth library, and create a new GoogleAuth client.
+ * Shows API key usage in GCP libraries
+ *
+ * @param {string} googleApiKey - API key value you want to use.
  */
-const {GoogleAuth} = require('google-auth-library');
+function main(googleApiKey) {
+  // [START auth_cloud_api_key]
+  /**
+   * TODO(developer):
+   *  1. Uncomment and replace these variables before running the sample.
+   *  2. Create an API key as described in https://cloud.google.com/docs/authentication/api-keys
+   */
+  // const googleApiKey = 'YOUR_API_KEY';
 
-/**
- * Acquire a client, and make a request to an API that's enabled by default.
- */
-async function main() {
-  const auth = new GoogleAuth({
-    apiKey: 'fill in the API key',
-  });
+  const language = require('@google-cloud/language');
 
-  const client = await auth.getClient();
-  const url = 'https://language.googleapis.com/v1/documents:analyzeSentiment';
-  const body =
-    "{'document':{'type':'PLAIN_TEXT','content':'hello world'},'encodingType':'UTF8'}";
-  const res = await client.request({url: url, method: 'POST', body: body});
-  console.log(res.data);
+  async function authenticateWithApiKey() {
+    // This snippet demonstrates how to analyze sentiment.
+    const client = new language.LanguageServiceClient({apiKey: googleApiKey});
+
+    const text = 'Hello, World';
+    const document = {type: 'PLAIN_TEXT', content: text};
+    const analyzeSentimentRequest = {document: document, encodingType: 'UTF8'};
+
+    const [response] = await client.analyzeSentiment(analyzeSentimentRequest);
+    const sentiment = response.documentSentiment;
+    console.log(`Text: ${text}`);
+    console.log(`Sentiment score: ${sentiment.score}`);
+    console.log(`Sentiment magnitude: ${sentiment.magnitude}`);
+  }
+
+  authenticateWithApiKey();
+  // [END auth_cloud_api_key]
 }
 
-main().catch(console.error);
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
+main(...process.argv.slice(2));

--- a/samples/package.json
+++ b/samples/package.json
@@ -13,6 +13,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@google-cloud/language": "^5.1.0",
     "@google-cloud/storage": "^6.0.0",
     "@googleapis/iam": "^3.0.0",
     "google-auth-library": "^8.7.0",

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -324,7 +324,7 @@ export class GoogleAuth<T extends AuthClient = JSONClient> {
     if (this.apiKey) {
       credential = this.fromAPIKey(this.apiKey);
       this.cachedCredential = credential;
-      let projectId = await this.getProjectIdOptional();
+      const projectId = await this.getProjectIdOptional();
       return {credential, projectId};
     }
 

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -88,6 +88,11 @@ export interface GoogleAuthOptions<T extends AuthClient = JSONClient> {
   keyFile?: string;
 
   /**
+   * Google API key value.
+   */
+  apiKey?: string;
+
+  /**
    * Object containing client_email and private_key properties, or the
    * external account client options.
    */
@@ -157,6 +162,7 @@ export class GoogleAuth<T extends AuthClient = JSONClient> {
   private keyFilename?: string;
   private scopes?: string | string[];
   private clientOptions?: RefreshOptions;
+  private apiKey?: string;
 
   /**
    * Export DefaultTransporter as a static property of the class.
@@ -172,6 +178,7 @@ export class GoogleAuth<T extends AuthClient = JSONClient> {
     this.scopes = opts.scopes;
     this.jsonContent = opts.credentials || null;
     this.clientOptions = opts.clientOptions;
+    this.apiKey = opts.apiKey;
   }
 
   // GAPIC client libraries should always use self-signed JWTs. The following
@@ -313,6 +320,14 @@ export class GoogleAuth<T extends AuthClient = JSONClient> {
     const quotaProjectIdOverride = process.env['GOOGLE_CLOUD_QUOTA_PROJECT'];
 
     let credential: JSONClient | null;
+
+    if (this.apiKey) {
+      credential = this.fromAPIKey(this.apiKey);
+      this.cachedCredential = credential;
+      let projectId = await this.getProjectIdOptional();
+      return {credential, projectId};
+    }
+
     // Check for the existence of a local environment variable pointing to the
     // location of the credential file. This is typically used in local
     // developer scenarios.

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -1131,6 +1131,14 @@ describe('googleauth', () => {
       assert.strictEqual(undefined, client.scope);
     });
 
+    it('getApplicationDefault should use API key if provided via options', async () => {
+      const auth = new GoogleAuth({apiKey: API_KEY});
+      const res = await auth.getApplicationDefault();
+      const headers = await res.credential.getRequestHeaders();
+      assert.strictEqual(headers['X-Goog-Api-Key'], API_KEY);
+      assert.strictEqual(res.projectId, null);
+    });
+
     it('_checkIsGCE should set the _isGCE flag when running on GCE', async () => {
       assert.notStrictEqual(true, auth.isGCE);
       const scope = nockIsGCE();


### PR DESCRIPTION
Add api key support. The feature has been tested with the following sample: 

https://github.com/arithmetic1728/nodejs-api-key-sample/blob/main/index.js

```
async function main() { 
    const language = require('@google-cloud/language'); 

    const client = new language.LanguageServiceClient({'apiKey': '<FILL IN THE API KEY>'});
    
    const text = 'Hello, World'; 
    const document = { type: 'PLAIN_TEXT', content: text, }; 
    const analyzeSentimentRequest = { document: document, encodingType: 'UTF8', };
    try { 
        const [response] = await client.analyzeSentiment(analyzeSentimentRequest); 
        const sentiment = response.documentSentiment; 
        console.log(`Text: ${text}`); 
        console.log(`Sentiment score: ${sentiment.score}`); 
        console.log(`Sentiment magnitude: ${sentiment.magnitude}`); 
    } catch (err) { 
        console.log(err) 
    } 
} 

main()
```

