### PR TITLE
fix: do not call metadata server if security creds and region are retrievable through environment vars

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,15 +46,3 @@ jobs:
           node-version: 14
       - run: npm install
       - run: npm run lint
-  docs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 14
-      - run: npm install
-      - run: npm run docs
-      - uses: JustinBeckwith/linkinator-action@v1
-        with:
-          paths: docs/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,3 +46,15 @@ jobs:
           node-version: 14
       - run: npm install
       - run: npm run lint
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+      - run: npm install
+      - run: npm run docs
+      - uses: JustinBeckwith/linkinator-action@v1
+        with:
+          paths: docs/

--- a/src/auth/awsclient.ts
+++ b/src/auth/awsclient.ts
@@ -346,10 +346,13 @@ export class AwsClient extends BaseExternalAccountClient {
   }
 
   private canRetrieveRegionFromEnvironment(): boolean {
+    // The AWS region can be provided through AWS_REGION or AWS_DEFAULT_REGION.
+    // Only one is required.
     return !!(process.env['AWS_REGION'] || process.env['AWS_DEFAULT_REGION']);
   }
 
   private canRetrieveSecurityCredentialsFromEnvironment(): boolean {
+    // Check if both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are available.
     return !!(
       process.env['AWS_ACCESS_KEY_ID'] && process.env['AWS_SECRET_ACCESS_KEY']
     );

--- a/src/auth/awsclient.ts
+++ b/src/auth/awsclient.ts
@@ -343,7 +343,9 @@ export class AwsClient extends BaseExternalAccountClient {
   private get regionFromEnv(): string | null {
     // The AWS region can be provided through AWS_REGION or AWS_DEFAULT_REGION.
     // Only one is required.
-    return process.env['AWS_REGION'] || process.env['AWS_DEFAULT_REGION'] || null;
+    return (
+      process.env['AWS_REGION'] || process.env['AWS_DEFAULT_REGION'] || null
+    );
   }
 
   private get securityCredentialsFromEnv(): AwsSecurityCredentials | null {

--- a/src/auth/awsclient.ts
+++ b/src/auth/awsclient.ts
@@ -340,10 +340,10 @@ export class AwsClient extends BaseExternalAccountClient {
     return !this.regionFromEnv || !this.securityCredentialsFromEnv;
   }
 
-  private get regionFromEnv(): string | undefined {
+  private get regionFromEnv(): string | null {
     // The AWS region can be provided through AWS_REGION or AWS_DEFAULT_REGION.
     // Only one is required.
-    return process.env['AWS_REGION'] || process.env['AWS_DEFAULT_REGION'];
+    return process.env['AWS_REGION'] || process.env['AWS_DEFAULT_REGION'] || null;
   }
 
   private get securityCredentialsFromEnv(): AwsSecurityCredentials | null {

--- a/src/auth/awsrequestsigner.ts
+++ b/src/auth/awsrequestsigner.ts
@@ -40,7 +40,7 @@ interface AwsAuthHeaderMap {
  * These are either determined from AWS security_credentials endpoint or
  * AWS environment variables.
  */
-interface AwsSecurityCredentials {
+export interface AwsSecurityCredentials {
   accessKeyId: string;
   secretAccessKey: string;
   token?: string;


### PR DESCRIPTION
Fixes an issue introduced by the AWS IMDSv2 changes where the metadata server is being called even if everything is retrievable through the defined environment variables.