### PR TITLE
refactor: increase upper webpack bundle limit

### DIFF
--- a/system-test/test.kitchen.ts
+++ b/system-test/test.kitchen.ts
@@ -64,7 +64,7 @@ describe('pack and install', () => {
     await execa('npx', ['webpack'], {cwd: `${stagingDir}/`, stdio: 'inherit'});
     const bundle = path.join(stagingDir, 'dist', 'bundle.min.js');
     const stat = fs.statSync(bundle);
-    assert(stat.size < 256 * 1024);
+    assert(stat.size < 512 * 1024);
   });
 
   /**


### PR DESCRIPTION
Tests are failing in other PRs due to increase in the package's bundled size. 🦕
