### PR TITLE
feat: Expose `gcp-metadata`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@
 // limitations under the License.
 import {GoogleAuth} from './auth/googleauth';
 
+export * as gcpMetadata from 'gcp-metadata';
+
 export {AuthClient} from './auth/authclient';
 export {Compute, ComputeOptions} from './auth/computeclient';
 export {


### PR DESCRIPTION
Makes it more convenient for folks looking to use this library's `gcp-metadata` rather than installing separately.

🦕
