### PR TITLE
fix(GoogleAuth): Expand `credentials` type

### DIFF
--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -102,7 +102,7 @@ export interface GoogleAuthOptions<T extends AuthClient = JSONClient> {
    * Object containing client_email and private_key properties, or the
    * external account client options.
    */
-  credentials?: CredentialBody | ExternalAccountClientOptions;
+  credentials?: JWTInput | ExternalAccountClientOptions;
 
   /**
    * Options object passed to the constructor of the client


### PR DESCRIPTION
Currently the `GoogleAuthOptions.credentials` type parameter is more limited in properties than the `GoogleAuth#fromJSON` method, although in the code paths they are used in the same way.

This fixes problems for customers looking to provide credentials directly to `GoogleAuth`'s constructor.

Background:
- https://github.com/googleapis/nodejs-storage/issues/2385

🦕
