### PR TITLE
refactor: Consistency Between Langs

### DIFF
--- a/src/auth/downscopedclient.ts
+++ b/src/auth/downscopedclient.ts
@@ -73,13 +73,6 @@ export interface CredentialAccessBoundary {
   accessBoundary: {
     accessBoundaryRules: AccessBoundaryRule[];
   };
-  /**
-   * An optional STS access token exchange endpoint.
-   *
-   * @example
-   * 'https://sts.googleapis.com/v1/token'
-   */
-  tokenURL?: string | URL;
 }
 
 /** Defines an upper bound of permissions on a particular resource. */
@@ -141,11 +134,6 @@ export class DownscopedClient extends AuthClient {
   ) {
     super({...additionalOptions, quotaProjectId});
 
-    // extract and remove `tokenURL` as it is not officially a part of the credentialAccessBoundary
-    this.credentialAccessBoundary = {...credentialAccessBoundary};
-    const tokenURL = this.credentialAccessBoundary.tokenURL;
-    delete this.credentialAccessBoundary.tokenURL;
-
     // Check 1-10 Access Boundary Rules are defined within Credential Access
     // Boundary.
     if (
@@ -174,7 +162,7 @@ export class DownscopedClient extends AuthClient {
     }
 
     this.stsCredential = new sts.StsCredentials(
-      tokenURL || `https://sts.${this.universeDomain}/v1/token`
+      `https://sts.${this.universeDomain}/v1/token`
     );
 
     this.cachedDownscopedAccessToken = null;

--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -531,12 +531,14 @@ export class OAuth2Client extends AuthClient {
     this.redirectUri = opts.redirectUri;
 
     this.endpoints = {
-      tokenInfoUrl: `https://oauth2.${this.universeDomain}/tokeninfo`,
+      tokenInfoUrl: 'https://oauth2.googleapis.com/tokeninfo',
       oauth2AuthBaseUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
-      oauth2TokenUrl: `https://oauth2.${this.universeDomain}/token`,
-      oauth2RevokeUrl: `https://oauth2.${this.universeDomain}/revoke`,
-      oauth2FederatedSignonPemCertsUrl: `https://www.${this.universeDomain}/oauth2/v1/certs`,
-      oauth2FederatedSignonJwkCertsUrl: `https://www.${this.universeDomain}/oauth2/v3/certs`,
+      oauth2TokenUrl: 'https://oauth2.googleapis.com/token',
+      oauth2RevokeUrl: 'https://oauth2.googleapis.com/revoke',
+      oauth2FederatedSignonPemCertsUrl:
+        'https://www.googleapis.com/oauth2/v1/certs',
+      oauth2FederatedSignonJwkCertsUrl:
+        'https://www.googleapis.com/oauth2/v3/certs',
       oauth2IapPublicKeyUrl: 'https://www.gstatic.com/iap/verify/public_key',
       ...opts.endpoints,
     };

--- a/test/test.downscopedclient.ts
+++ b/test/test.downscopedclient.ts
@@ -325,42 +325,6 @@ describe('DownscopedClient', () => {
         refreshOptions.eagerRefreshThresholdMillis
       );
     });
-
-    it('should use a tokenURL', async () => {
-      const tokenURL = new URL('https://my-token-url/v1/token');
-      const scope = mockStsTokenExchange(
-        [
-          {
-            statusCode: 200,
-            response: stsSuccessfulResponse,
-            request: {
-              grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
-              requested_token_type:
-                'urn:ietf:params:oauth:token-type:access_token',
-              subject_token: 'subject_token_0',
-              subject_token_type:
-                'urn:ietf:params:oauth:token-type:access_token',
-              options: JSON.stringify(testClientAccessBoundary),
-            },
-          },
-        ],
-        undefined,
-        tokenURL.origin
-      );
-
-      const downscopedClient = new DownscopedClient(client, {
-        ...testClientAccessBoundary,
-        tokenURL,
-      });
-
-      const tokenResponse = await downscopedClient.getAccessToken();
-      assert.deepStrictEqual(
-        tokenResponse.token,
-        stsSuccessfulResponse.access_token
-      );
-
-      scope.done();
-    });
   });
 
   describe('setCredential()', () => {


### PR DESCRIPTION
- Removed `tokenURL` from Downscoped Client (was not included in a release)
- Reverted OAuth2 endpoints to googleapis.com