### PR TITLE
fix!: Update OAuth2Client Endpoints to JWT Versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14, 16, 18, 20]
+        node: [16, 18, 20, 21]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-node@v4
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 21
       - run: npm install
       - run: npm test
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [16, 18, 20, 21]
+        node: [14, 16, 18, 20]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-node@v4
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 21
+          node-version: 14
       - run: npm install
       - run: npm test
         env:

--- a/samples/test/auth.test.js
+++ b/samples/test/auth.test.js
@@ -69,7 +69,7 @@ describe('auth samples', () => {
     const idToken = await client.fetchIdToken(TARGET_AUDIENCE);
 
     const output = execSync(
-      `node verifyGoogleIdToken ${idToken} ${TARGET_AUDIENCE} https://www.googleapis.com/oauth2/v3/certs`
+      `node verifyGoogleIdToken ${idToken} ${TARGET_AUDIENCE}`
     );
 
     assert.match(output, /ID token verified./);

--- a/src/crypto/node/crypto.ts
+++ b/src/crypto/node/crypto.ts
@@ -49,11 +49,27 @@ export class NodeCrypto implements Crypto {
     }
   }
 
-  async sign(privateKey: string, data: string | Buffer): Promise<string> {
+  async sign(
+    privateKey: string | JwkCertificate | crypto.JsonWebKey,
+    data: string | Buffer
+  ): Promise<string> {
     const signer = crypto.createSign('RSA-SHA256');
     signer.update(data);
     signer.end();
-    return signer.sign(privateKey, 'base64');
+
+    if (typeof privateKey === 'string') {
+      // must be PEM
+      return signer.sign(privateKey, 'base64');
+    } else {
+      // must be JWK
+      return signer.sign(
+        {
+          key: privateKey as unknown as crypto.KeyObject,
+          format: 'jwk',
+        },
+        'base64'
+      );
+    }
   }
 
   decodeBase64StringUtf8(base64: string): string {

--- a/test/fixtures/oauthcerts.json
+++ b/test/fixtures/oauthcerts.json
@@ -1,0 +1,20 @@
+{
+  "keys": [
+    {
+      "n": "q0CrF3x3aYsjr0YOLMOAhEGMvyFp6o4RqyEdUrnTDYkhZbcud-fJEQafCTnjS9QHN1IjpuK6gpx5i3-Z63vRjs5EQX7lP1jG8Qg-CnBdTTLw4uJi7RmmlKPsYaO1DbNkFO2uEN62sOOzmJCh1od3CZXI1UYH5cvZ_sLJaN2A4TwvUTU3aXlXbUNJz_Hy3l0q1Jjta75NrJtJ7Pfj9tVXs8qXp15tZXrnbaM-AI0puswt35VsQbmLwUovFFGeToo5q2c_c1xYnV5uQYMadANekGPRFPM9JZpSSIvH0Lv_f15V2zRqmIgX7a3RcmTnr3-w3QNQTogdy-MogxPUdRbxow",
+      "kty": "RSA",
+      "use": "sig",
+      "kid": "55c188a83546fc188e51576ba72836e0600e8b73",
+      "alg": "RS256",
+      "e": "AQAB"
+    },
+    {
+      "n": "pOpd5-7RpMvcfBcSjqlTNYjGg3YRwYRV9T9k7eDOEWgMBQEs6ii3cjcuoa1oD6N48QJmcNvAme_ud985DV2mQpOaCUy22MVRKI8DHxAKGWzZO5yzn6otsN9Vy0vOEO_I-vnmrO1-1ONFuH2zieziaXCUVh9087dRkM9qaQYt6QJhMmiNpyrbods6AsU8N1jeAQl31ovHWGGk8axXNmwbx3dDZQhx-t9ZD31oF-usPhFZtM92mxgehDqi2kpvFmM0nzSVgPrOXlbDb9ztg8lclxKwnT1EtcwHUq4FeuOPQMtZ2WehrY10OvsqS5ml3mxXUQEXrtYfa5V1v4o3rWx9Ow",
+      "alg": "RS256",
+      "kty": "RSA",
+      "e": "AQAB",
+      "kid": "6f9777a685907798ef794062c00b65d66c240b1b",
+      "use": "sig"
+    }
+  ]
+}

--- a/test/test.crypto.ts
+++ b/test/test.crypto.ts
@@ -15,11 +15,17 @@
 import * as fs from 'fs';
 import {assert} from 'chai';
 import {describe, it} from 'mocha';
-import {createCrypto, fromArrayBufferToHex} from '../src/crypto/crypto';
+import {
+  JwkCertificate,
+  createCrypto,
+  fromArrayBufferToHex,
+} from '../src/crypto/crypto';
 import {NodeCrypto} from '../src/crypto/node/crypto';
+import {createPublicKey} from 'crypto';
 
 const publicKey = fs.readFileSync('./test/fixtures/public.pem', 'utf-8');
 const privateKey = fs.readFileSync('./test/fixtures/private.pem', 'utf-8');
+const jwtPublicKeyJWT = createPublicKey(publicKey).export({format: 'jwk'});
 
 /**
  * Converts a Node.js Buffer to an ArrayBuffer.
@@ -63,7 +69,25 @@ describe('crypto', () => {
     assert.notStrictEqual(generated1Base64, generated2Base64);
   });
 
-  it('should verify a signature', async () => {
+  it('should verify a signature (JWK)', async () => {
+    const message = 'This message is signed';
+    const signatureBase64 = [
+      'ufyKBV+Ar7Yq8CSmSIN9m38ch4xnWBz8CP4qHh6V+',
+      'm4cCbeXdR1MEmWVhNJjZQFv3KL3tDAnl0Q4bTcSR/',
+      'mmhXaRjdxyJ6xAUp0KcbVq6xsDIbnnYHSgYr3zVoS',
+      'dRRefWSWTknN1S69fNmKEfUeBIJA93xitr3pbqtLC',
+      'bP28XNU',
+    ].join(''); // note: no padding
+
+    const verified = await crypto.verify(
+      jwtPublicKeyJWT as unknown as JwkCertificate,
+      message,
+      signatureBase64
+    );
+    assert(verified);
+  });
+
+  it('should verify a signature (PEM)', async () => {
     const message = 'This message is signed';
     const signatureBase64 = [
       'ufyKBV+Ar7Yq8CSmSIN9m38ch4xnWBz8CP4qHh6V+',

--- a/test/test.crypto.ts
+++ b/test/test.crypto.ts
@@ -101,7 +101,7 @@ describe('crypto', () => {
     assert(verified);
   });
 
-  it('should sign a message (JWT)', async () => {
+  it('should sign a message (JWK)', async () => {
     const message = 'This message is signed';
     const expectedSignatureBase64 = [
       'ufyKBV+Ar7Yq8CSmSIN9m38ch4xnWBz8CP4qHh6V+',

--- a/test/test.crypto.ts
+++ b/test/test.crypto.ts
@@ -21,11 +21,12 @@ import {
   fromArrayBufferToHex,
 } from '../src/crypto/crypto';
 import {NodeCrypto} from '../src/crypto/node/crypto';
-import {createPublicKey} from 'crypto';
+import {createPrivateKey, createPublicKey} from 'crypto';
 
 const publicKey = fs.readFileSync('./test/fixtures/public.pem', 'utf-8');
 const privateKey = fs.readFileSync('./test/fixtures/private.pem', 'utf-8');
 const jwtPublicKeyJWT = createPublicKey(publicKey).export({format: 'jwk'});
+const jwtPrivateKeyJWT = createPrivateKey(privateKey).export({format: 'jwk'});
 
 /**
  * Converts a Node.js Buffer to an ArrayBuffer.
@@ -100,7 +101,24 @@ describe('crypto', () => {
     assert(verified);
   });
 
-  it('should sign a message', async () => {
+  it('should sign a message (JWT)', async () => {
+    const message = 'This message is signed';
+    const expectedSignatureBase64 = [
+      'ufyKBV+Ar7Yq8CSmSIN9m38ch4xnWBz8CP4qHh6V+',
+      'm4cCbeXdR1MEmWVhNJjZQFv3KL3tDAnl0Q4bTcSR/',
+      'mmhXaRjdxyJ6xAUp0KcbVq6xsDIbnnYHSgYr3zVoS',
+      'dRRefWSWTknN1S69fNmKEfUeBIJA93xitr3pbqtLC',
+      'bP28XNU=',
+    ].join('');
+
+    const signatureBase64 = await crypto.sign(
+      jwtPrivateKeyJWT as unknown as JwkCertificate,
+      message
+    );
+    assert.strictEqual(signatureBase64, expectedSignatureBase64);
+  });
+
+  it('should sign a message (PEM)', async () => {
     const message = 'This message is signed';
     const expectedSignatureBase64 = [
       'ufyKBV+Ar7Yq8CSmSIN9m38ch4xnWBz8CP4qHh6V+',


### PR DESCRIPTION
The PEM endpoints have been long-deprecated and are causing issues for customers.

As a dependency, added `JWK` support to `NodeCrypto`.

Related:
- googleapis/google-cloud-node-core#514
- https://github.com/googleapis/node-gtoken/pull/466

Fixes: googleapis/google-cloud-node-core#514 🦕
