### PR TITLE
build: remove `compodoc`

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "jws": "^4.0.0"
   },
   "devDependencies": {
-    "@compodoc/compodoc": "^1.1.7",
     "@types/base64-js": "^1.2.5",
     "@types/chai": "^4.1.7",
     "@types/jws": "^3.1.0",
@@ -74,7 +73,7 @@
     "compile": "tsc -p .",
     "fix": "gts fix",
     "pretest": "npm run compile -- --sourceMap",
-    "docs": "compodoc src/",
+    "docs": "",
     "samples-setup": "cd samples/ && npm link ../ && npm run setup && cd ../",
     "samples-test": "cd samples/ && npm link ../ && npm test && cd ../",
     "system-test": "mocha build/system-test --timeout 60000",


### PR DESCRIPTION
It's constantly introducing breaking changes in patch releases and its unclear who's using it. Today its blocking all other PRs in this repo.

Let's drop it.

🦕
