### PR TITLE
fix: add missing return value to `fromAPIKey`

### DIFF
--- a/src/auth/jwtclient.ts
+++ b/src/auth/jwtclient.ts
@@ -377,12 +377,15 @@ export class JWT extends OAuth2Client implements IdTokenProvider {
   /**
    * Creates a JWT credentials instance using an API Key for authentication.
    * @param apiKey The API Key in string form.
+   * @return The current instance.
    */
   fromAPIKey(apiKey: string): void {
     if (typeof apiKey !== 'string') {
       throw new Error('Must provide an API Key string.');
     }
     this.apiKey = apiKey;
+
+    return this;
   }
 
   /**


### PR DESCRIPTION
According to [the docs](https://cloud.google.com/nodejs/docs/reference/google-auth-library/latest/google-auth-library/googleauth#google_auth_library_GoogleAuth_fromAPIKey_member_1_), the `fromAPIKey` function should return an instance of the class again, but returns `void` in the actual code.

To properly use it in chaining scenarios, e.g. `const client = new JWT().fromAPIKey('<api-key>')`, this issue should be addressed.