### PR TITLE
docs(readme): add example for service_account_impersonation_url in clientOptions

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -434,6 +434,7 @@ body: |-
     audience: '//iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$WORKLOAD_POOL_ID/providers/$PROVIDER_ID', // Set the GCP audience.
     subject_token_type: 'urn:ietf:params:aws:token-type:aws4_request', // Set the subject token type.
     aws_security_credentials_supplier: new AwsSupplier("AWS_REGION") // Set the custom supplier.
+    service_account_impersonation_url: 'https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/$EMAIL:generateAccessToken', // Set the service account impersonation url.
   }
 
   // Create a new Auth client and use it to create service client, i.e. storage.

--- a/README.md
+++ b/README.md
@@ -478,6 +478,7 @@ const clientOptions = {
   audience: '//iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$WORKLOAD_POOL_ID/providers/$PROVIDER_ID', // Set the GCP audience.
   subject_token_type: 'urn:ietf:params:aws:token-type:aws4_request', // Set the subject token type.
   aws_security_credentials_supplier: new AwsSupplier("AWS_REGION") // Set the custom supplier.
+  service_account_impersonation_url: 'https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/$EMAIL:generateAccessToken', // Set the service account impersonation url.
 }
 
 // Create a new Auth client and use it to create service client, i.e. storage.


### PR DESCRIPTION
Thank you for implementing support for passing custom AWS credentials in your library. Your efforts are much appreciated.

While I was working on implementing the custom supplier, I noticed that the `service_account_impersonation_url` field is missing from the `clientOptions` object in your documentation. Without including this field, a permissions error is thrown during execution. This PR adds that field to the README