### PR TITLE
feat: Implement TrustBoundaries

### DIFF
--- a/src/auth/authclient.ts
+++ b/src/auth/authclient.ts
@@ -20,7 +20,7 @@ import {OriginalAndCamel, originalOrCamelOptions} from '../util';
 import {log as makeLog} from 'google-logging-utils';
 
 import {PRODUCT_NAME, USER_AGENT} from '../shared.cjs';
-import { TrustBoundary, TrustBoundaryData } from './trustboundary';
+import { TrustBoundaryData } from './trustboundary';
 
 /**
  * Easy access to symbol-indexed strings on config objects.
@@ -218,6 +218,7 @@ export abstract class AuthClient
   eagerRefreshThresholdMillis = DEFAULT_EAGER_REFRESH_THRESHOLD_MILLIS;
   forceRefreshOnFailure = false;
   universeDomain = DEFAULT_UNIVERSE;
+  trustBoundaryEnabled: boolean
   trustBoundary?: TrustBoundaryData | null;
 
   /**
@@ -234,6 +235,7 @@ export abstract class AuthClient
     super();
 
     const options = originalOrCamelOptions(opts);
+    const tbEnvEnabled = process.env['GOOGLE_AUTH_ENABLE_TRUST_BOUNDARIES'];
 
     // Shared auth options
     this.apiKey = opts.apiKey;
@@ -241,6 +243,7 @@ export abstract class AuthClient
     this.quotaProjectId = options.get('quota_project_id');
     this.credentials = options.get('credentials') ?? {};
     this.universeDomain = options.get('universe_domain') ?? DEFAULT_UNIVERSE;
+    this.trustBoundaryEnabled = tbEnvEnabled ? tbEnvEnabled.toLowerCase() === 'true' : false; 
     this.trustBoundary = null;
 
     // Shared client options

--- a/src/auth/authclient.ts
+++ b/src/auth/authclient.ts
@@ -20,6 +20,7 @@ import {OriginalAndCamel, originalOrCamelOptions} from '../util';
 import {log as makeLog} from 'google-logging-utils';
 
 import {PRODUCT_NAME, USER_AGENT} from '../shared.cjs';
+import { TrustBoundary, TrustBoundaryData } from './trustboundary';
 
 /**
  * Easy access to symbol-indexed strings on config objects.
@@ -217,6 +218,7 @@ export abstract class AuthClient
   eagerRefreshThresholdMillis = DEFAULT_EAGER_REFRESH_THRESHOLD_MILLIS;
   forceRefreshOnFailure = false;
   universeDomain = DEFAULT_UNIVERSE;
+  trustBoundary?: TrustBoundaryData | null;
 
   /**
    * Symbols that can be added to GaxiosOptions to specify the method name that is
@@ -239,6 +241,7 @@ export abstract class AuthClient
     this.quotaProjectId = options.get('quota_project_id');
     this.credentials = options.get('credentials') ?? {};
     this.universeDomain = options.get('universe_domain') ?? DEFAULT_UNIVERSE;
+    this.trustBoundary = null;
 
     // Shared client options
     this.transporter = opts.transporter ?? new Gaxios(opts.transporterOptions);
@@ -314,6 +317,12 @@ export abstract class AuthClient
     ) {
       headers.set('x-goog-user-project', this.quotaProjectId);
     }
+    if (
+      !headers.has('x-goog-allowed-locations') && // don't override a value the user sets.
+      this.trustBoundary && this.trustBoundary.encodedLocations
+    ) {
+      headers.set('x-goog-allowed-locations', this.trustBoundary.encodedLocations);
+    }
     return headers;
   }
 
@@ -331,6 +340,7 @@ export abstract class AuthClient
   ): T {
     const xGoogUserProject = source.get('x-goog-user-project');
     const authorizationHeader = source.get('authorization');
+    const xGoogAllowedLocs = source.get('x-goog-allowed-locations');
 
     if (xGoogUserProject) {
       target.set('x-goog-user-project', xGoogUserProject);
@@ -338,6 +348,10 @@ export abstract class AuthClient
 
     if (authorizationHeader) {
       target.set('authorization', authorizationHeader);
+    }
+
+    if(xGoogAllowedLocs) {
+      target.set('x-goog-allowed-locations', xGoogAllowedLocs);
     }
 
     return target;

--- a/src/auth/authclient.ts
+++ b/src/auth/authclient.ts
@@ -20,7 +20,7 @@ import {OriginalAndCamel, originalOrCamelOptions} from '../util';
 import {log as makeLog} from 'google-logging-utils';
 
 import {PRODUCT_NAME, USER_AGENT} from '../shared.cjs';
-import {TrustBoundaryData} from './trustboundary';
+import {NoOpEncodedLocations, TrustBoundaryData} from './trustboundary';
 
 /**
  * Easy access to symbol-indexed strings on config objects.
@@ -326,9 +326,9 @@ export abstract class AuthClient
       headers.set('x-goog-user-project', this.quotaProjectId);
     }
     if (
-      !headers.has('x-goog-allowed-locations') &&
       this.trustBoundary &&
-      this.trustBoundary.encodedLocations
+      this.trustBoundary.encodedLocations &&
+      this.trustBoundary.encodedLocations !== NoOpEncodedLocations
     ) {
       headers.set(
         'x-goog-allowed-locations',
@@ -347,7 +347,7 @@ export abstract class AuthClient
    * @param source the headers to source from
    * @returns the target headers
    */
-  protected addUserProjectAndAuthHeaders<T extends Headers>(
+  protected addUserProjectAndAuthAndTBHeaders<T extends Headers>(
     target: T,
     source: Headers,
   ): T {

--- a/src/auth/baseexternalclient.ts
+++ b/src/auth/baseexternalclient.ts
@@ -511,7 +511,7 @@ export abstract class BaseExternalAccountClient
       const requestHeaders = await this.getRequestHeaders();
       opts.headers = Gaxios.mergeHeaders(opts.headers);
 
-      this.addUserProjectAndAuthHeaders(opts.headers, requestHeaders);
+      this.addUserProjectAndAuthAndTBHeaders(opts.headers, requestHeaders);
 
       response = await this.transporter.request<T>(opts);
     } catch (e) {

--- a/src/auth/downscopedclient.ts
+++ b/src/auth/downscopedclient.ts
@@ -290,7 +290,7 @@ export class DownscopedClient extends AuthClient {
       const requestHeaders = await this.getRequestHeaders();
       opts.headers = Gaxios.mergeHeaders(opts.headers);
 
-      this.addUserProjectAndAuthHeaders(opts.headers, requestHeaders);
+      this.addUserProjectAndAuthAndTBHeaders(opts.headers, requestHeaders);
 
       response = await this.transporter.request<T>(opts);
     } catch (e) {

--- a/src/auth/externalAccountAuthorizedUserClient.ts
+++ b/src/auth/externalAccountAuthorizedUserClient.ts
@@ -259,7 +259,7 @@ export class ExternalAccountAuthorizedUserClient extends AuthClient {
       const requestHeaders = await this.getRequestHeaders();
       opts.headers = Gaxios.mergeHeaders(opts.headers);
 
-      this.addUserProjectAndAuthHeaders(opts.headers, requestHeaders);
+      this.addUserProjectAndAuthAndTBHeaders(opts.headers, requestHeaders);
 
       response = await this.transporter.request<T>(opts);
     } catch (e) {

--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -1119,7 +1119,7 @@ export class OAuth2Client extends AuthClient {
       const r = await this.getRequestMetadataAsync();
       opts.headers = Gaxios.mergeHeaders(opts.headers);
 
-      this.addUserProjectAndAuthHeaders(opts.headers, r.headers);
+      this.addUserProjectAndAuthAndTBHeaders(opts.headers, r.headers);
 
       if (this.apiKey) {
         opts.headers.set('X-Goog-Api-Key', this.apiKey);

--- a/src/auth/trustboundary.ts
+++ b/src/auth/trustboundary.ts
@@ -1,0 +1,245 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { AuthClient } from './authclient';
+import { GaxiosError, GaxiosOptions, GaxiosResponse } from 'gaxios';
+
+
+// NoOpEncodedLocations is a special value indicating that no trust boundary is enforced.
+const NoOpEncodedLocations = "0x0";
+// universeDomainDefault is the default domain for Google Cloud Universe.
+const universeDomainDefault = "googleapis.com";
+// ServiceAccountAllowedLocationsEndpoint is the URL for fetching allowed locations for a given service account email.
+// The '%s' will be replaced with the URL-encoded service account email.
+const ServiceAccountAllowedLocationsEndpoint = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s/allowedLocations";
+
+
+// --- Interfaces ---
+
+/**
+ * Holds trust boundary related information like locations
+ * where the credentials can be used.
+ */
+export interface TrustBoundaryData {
+    /**
+     * The readable text format of the allowed trust boundary locations.
+     * This is optional, as it might not be present if no trust boundary is enforced.
+     */
+    locations?: string[];
+
+    /**
+     * The encoded text format of allowed trust boundary locations.
+     * Expected to always be present in valid responses.
+     */
+    encodedLocations: string;
+}
+
+/**
+ * This interface allows different authentication types to pass info
+ * Service Account -> email
+ * Workload Identity Pool -> project_id, pool_id
+ * Workforce Pool -> pool_id
+ */
+export interface TrustBoundaryDescriptor {
+  project_id?: string,
+  pool_id?: string,
+  email?: string
+}
+  
+export interface TrustBoundaryProvider {
+  fetchTrustBoundary: (tbDescriptor: TrustBoundaryDescriptor) => Promise<TrustBoundaryData|null>;
+}
+
+// --- TrustBoundary Class ---
+
+/**
+ * Represents trust boundary information, holding allowed locations.
+ */
+export class TrustBoundary {
+    // The readable text format of the allowed trust boundary locations
+    readonly locations?: string[];
+    // The encoded text format of allowed trust boundary locations
+    readonly encodedLocations: string;
+
+    /**
+     * Creates an instance of TrustBoundary.
+     * @param locations Optional array of allowed location strings.
+     * @param encodedLocations The encoded location string. Defaults to NoOpEncodedLocations.
+     */
+    constructor (
+        locations?: string[],
+        encodedLocations : string = NoOpEncodedLocations
+    ) {
+        // Store a copy of the locations array if provided
+        this.locations = locations ? [...locations] : undefined;
+        this.encodedLocations = encodedLocations;
+    }
+
+    /**
+     * Gets a copy of the allowed locations array.
+     * @returns A copy of the locations array, or undefined if not set.
+     */
+    getLocations(): string[] | undefined {
+        return this.locations ? [...this.locations] : undefined;
+    }
+
+    /**
+     * Gets the encoded locations string.
+     * @returns The encoded locations string.
+     */
+    getEncodedLocations(): string {
+        return this.encodedLocations ? this.encodedLocations : "";
+    }
+
+    /**
+     * Checks if the trust boundary is effectively empty or represents no restrictions.
+     * @returns True if no encoded locations are set or if it's the No-Op value, false otherwise.
+     */
+    isNoOpOrEmpty(): boolean {
+        return !this.encodedLocations || this.encodedLocations === NoOpEncodedLocations;
+    }
+}
+
+
+
+// --- Internal Helper Function ---
+
+/**
+ * Internal helper function to fetch trust boundary data from a specific URL.
+ * Corresponds to Go's fetchTrustBoundaryData.
+ *
+ * @param authenticatedClient An authenticated AuthClient instance.
+ * @param url The specific URL to fetch data from.
+ * @returns A Promise resolving to a new TrustBoundary instance.
+ * @throws {Error} If the request fails or the response is invalid.
+ * @internal
+ */
+async function _fetchTrustBoundaryData(
+  authenticatedClient: AuthClient,
+  url: string,
+): Promise<TrustBoundaryData> { // Throws on error instead of returning null
+
+  if (!url) {
+      throw new Error("TrustBoundary: URL cannot be empty for fetching data.");
+  }
+
+  const requestOptions: GaxiosOptions = {
+    method: 'GET',
+    url: url,
+    timeout: 5000, // todo: make this configurable 5 seconds
+  };
+
+  console.log(`TrustBoundary: Fetching data from ${url}`);
+  try {
+    const response: GaxiosResponse<TrustBoundaryData> = await authenticatedClient.transporter.request<TrustBoundaryData>(requestOptions)
+    console.log("Response from lookup endpoint "+ response)
+    // const response: GaxiosResponse<AllowedLocationsResponse> = await authenticatedClient.request<AllowedLocationsResponse>(requestOptions);
+    if (response.status === 200 && response.data) {
+      const trustBoundaryData = response.data;
+
+      // Basic validation of the response structure
+      if (typeof trustBoundaryData.encodedLocations !== 'string') {
+         throw new Error('TrustBoundary: Invalid response format - missing or invalid encodedLocations');
+      }
+
+      console.log('TrustBoundary: Successfully fetched data.');
+      return trustBoundaryData
+
+    } else {
+      // Handle unexpected non-error statuses (though gaxios usually throws for >=400)
+      throw new Error(`TrustBoundary: Request failed with status ${response.status}`);
+    }
+  } catch (error) {
+    console.error(`TrustBoundary: Failed request to ${url}.`);
+    if (error instanceof GaxiosError) {
+      console.error(`Status: ${error.response?.status}, Message: ${error.message}, Body:`, error.response?.data);
+      // Re-throw a more specific error or the original GaxiosError
+      throw new Error(`TrustBoundary: API request failed with status ${error.response?.status}: ${error.message}`);
+    } else if (error instanceof Error) {
+      // Re-throw the original error or wrap it
+      throw new Error(`TrustBoundary: Network or unexpected error: ${error.message}`);
+    } else {
+      // Handle unknown error types
+      throw new Error(`TrustBoundary: An unknown error occurred during fetch: ${error}`);
+    }
+  }
+}
+
+
+// --- Exported Lookup Function ---
+
+/**
+ * Fetches trust boundary data for a given service account email using an authenticated client.
+ * Handles caching checks and potential fallbacks.
+ * Corresponds to Go's LookupServiceAccountTrustBoundary.
+ *
+ * @param authenticatedClient An authenticated AuthClient instance to make the request.
+ * @param serviceAccountEmail The email of the service account to look up.
+ * @param cachedData Optional previously fetched data to check for no-op or use as fallback on error.
+ * @returns A Promise resolving to TrustBoundaryData or null if fetching fails and no cache is available.
+ */
+export async function lookupServiceAccountTrustBoundary(
+  authenticatedClient: AuthClient,
+  serviceAccountEmail?: string,
+  cachedData?: TrustBoundaryData|null
+): Promise<TrustBoundaryData | null> { // Returns null on unrecoverable error with no cache
+
+  // --- Input Validation ---
+  if (!authenticatedClient) {
+    console.error('TrustBoundaryLookup: Authenticated client is required.');
+    return cachedData ?? null; // Use cache if available, else null
+  }
+  if (!serviceAccountEmail) {
+    console.error('TrustBoundaryLookup: Service account email cannot be empty.');
+    return cachedData ?? null;
+  }
+
+  // --- Check Universe Domain ---
+  const universeDomain = authenticatedClient.universeDomain || universeDomainDefault;
+  if (universeDomain !== universeDomainDefault) {
+    console.log(`TrustBoundaryLookup: Skipping check for non-default universe domain: ${universeDomain}`);
+    return new TrustBoundary(undefined, NoOpEncodedLocations); // Return No-Op
+  }
+
+  // --- Check Cached Data for No-Op ---
+  if (cachedData && cachedData.encodedLocations && cachedData.encodedLocations === NoOpEncodedLocations) {
+    console.log('TrustBoundaryLookup: Returning cached No-Op data.');
+    return cachedData;
+  }
+
+  // --- Prepare URL and Fetch --- 
+  const url = ServiceAccountAllowedLocationsEndpoint.replace('%s', encodeURIComponent(serviceAccountEmail));
+ 
+  try {
+    // Call the internal fetch function
+    return await _fetchTrustBoundaryData(authenticatedClient, url);
+  } catch (error) {
+    // --- Handle Errors and Fallback ---
+    console.error('TrustBoundaryLookup: Failed to fetch trust boundary data.');
+    if (error instanceof Error) {
+      console.error(error.message); // Log the specific error message
+    } else {
+      console.error('An unknown error occurred during lookup.', error);
+    }
+
+    // Fallback to cached data if available on error
+    if (cachedData) {
+      console.warn('TrustBoundaryLookup: Falling back to cached data due to error.');
+      return cachedData;
+    }
+
+    // If no cache, return null to indicate failure without fallback
+    return null;
+  }
+}

--- a/src/auth/trustboundary.ts
+++ b/src/auth/trustboundary.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { GoogleToken, TokenData } from 'gtoken';
 import { AuthClient } from './authclient';
 import { GaxiosError, GaxiosOptions, GaxiosResponse } from 'gaxios';
 
@@ -54,11 +55,16 @@ export interface TrustBoundaryData {
 export interface TrustBoundaryDescriptor {
   project_id?: string,
   pool_id?: string,
-  email?: string
+  email?: string,
+  tbEnabled?: boolean
 }
   
 export interface TrustBoundaryProvider {
-  fetchTrustBoundary: (tbDescriptor: TrustBoundaryDescriptor) => Promise<TrustBoundaryData|null>;
+  fetchTrustBoundary: (
+    tbDescriptor: TrustBoundaryDescriptor,
+    gToken: GoogleToken,
+    token: TokenData
+  ) => Promise<TrustBoundaryData|null>;
 }
 
 // --- TrustBoundary Class ---
@@ -142,7 +148,7 @@ async function _fetchTrustBoundaryData(
 
   console.log(`TrustBoundary: Fetching data from ${url}`);
   try {
-    const response: GaxiosResponse<TrustBoundaryData> = await authenticatedClient.transporter.request<TrustBoundaryData>(requestOptions)
+    const response: GaxiosResponse<TrustBoundaryData> = await authenticatedClient.request<TrustBoundaryData>(requestOptions)
     console.log("Response from lookup endpoint "+ response)
     // const response: GaxiosResponse<AllowedLocationsResponse> = await authenticatedClient.request<AllowedLocationsResponse>(requestOptions);
     if (response.status === 200 && response.data) {

--- a/test/test.baseexternalclient.ts
+++ b/test/test.baseexternalclient.ts
@@ -40,6 +40,11 @@ import {
   getExpectedExternalAccountMetricsHeaderValue,
 } from './externalclienthelper';
 import {DEFAULT_UNIVERSE} from '../src/auth/authclient';
+import {
+  TrustBoundaryData,
+  WORKFORCE_LOOKUP_ENDPOINT,
+  WORKLOAD_LOOKUP_ENDPOINT,
+} from '../src/auth/trustboundary';
 
 nock.disableNetConnect();
 
@@ -2597,6 +2602,125 @@ describe('BaseExternalAccountClient', () => {
       assert.deepStrictEqual(
         unexpiredTokenResponse.token,
         credentials.access_token,
+      );
+    });
+  });
+
+  describe('trust boundaries', () => {
+    let sandbox: sinon.SinonSandbox;
+
+    const baseWorkloadOptions: BaseExternalAccountClientOptions = {
+      type: 'external_account',
+      audience:
+        '//iam.googleapis.com/projects/12345/locations/global/workloadIdentityPools/my-pool/providers/my-provider',
+      subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
+      token_url: 'https://sts.googleapis.com/v1/token',
+    };
+
+    const baseWorkforceOptions: BaseExternalAccountClientOptions = {
+      type: 'external_account',
+      audience:
+        '//iam.googleapis.com/locations/global/workforcePools/my-workforce-pool/providers/my-workforce-provider',
+      subject_token_type: 'urn:ietf:params:oauth:token-type:id_token',
+      token_url: 'https://sts.googleapis.com/v1/token',
+      // workforce_pool_user_project: '67890',
+    };
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      process.env['GOOGLE_AUTH_ENABLE_TRUST_BOUNDARIES'] = 'true';
+    });
+
+    afterEach(() => {
+      delete process.env['GOOGLE_AUTH_ENABLE_TRUST_BOUNDARIES'];
+      sandbox.restore();
+      nock.cleanAll();
+    });
+
+    it('fetchTrustBoundary should return null when GOOGLE_AUTH_ENABLE_TRUST_BOUNDARIES env variable is false/null', async () => {
+      //TODO:pjiyer can this be moved to tb.ts file?
+      process.env['GOOGLE_AUTH_ENABLE_TRUST_BOUNDARIES'] = 'false';
+      const client = new TestExternalAccountClient(baseWorkforceOptions);
+
+      const mockAuthHeader = 'Bearer test-access-token';
+      const expectedTrustBoundaryData = null;
+
+      const trustBoundary = await client.fetchTrustBoundary(mockAuthHeader);
+
+      assert.deepStrictEqual(trustBoundary, expectedTrustBoundaryData);
+    });
+
+    it('fetchTrustBoundary should fetch and return trust boundary data for workforce successfully', async () => {
+      //TODO:pjiyer Can this be moved to tb.ts test file?
+      const client = new TestExternalAccountClient(baseWorkforceOptions);
+      const mockAuthHeader = 'Bearer test-access-token';
+      const expectedTrustBoundaryData: TrustBoundaryData = {
+        locations: ['sadad', 'asdad'],
+        encodedLocations: '000x9',
+      };
+      const lookupUrl = WORKFORCE_LOOKUP_ENDPOINT.replace(
+        '{pool_id}',
+        encodeURIComponent('my-workforce-pool'),
+      );
+
+      const scope = nock(new URL(lookupUrl).origin)
+        .get(new URL(lookupUrl).pathname)
+        .matchHeader('authorization', mockAuthHeader)
+        .reply(200, expectedTrustBoundaryData);
+
+      const trustBoundary = await client.fetchTrustBoundary(mockAuthHeader);
+
+      assert.deepStrictEqual(trustBoundary, expectedTrustBoundaryData);
+      scope.done();
+    });
+
+    it('fetchTrustBoundary should throw when audience is workforce and pool-id is null', async () => {
+      baseWorkforceOptions.audience =
+        '//iam.googleapis.com/locations/global/workforcePools/providers/my-workforce-provider';
+      const client = new TestExternalAccountClient(baseWorkforceOptions);
+      const mockAuthHeader = 'Bearer test-access-token';
+
+      await assert.rejects(
+        client.fetchTrustBoundary(mockAuthHeader),
+        /TrustBoundaryLookup: Failed to fetch trust boundary data due to missing workload pool id or project number/,
+      );
+    });
+
+    it('fetchTrustBoundary should fetch and return trust boundary data for workload successfully', async () => {
+      const client = new TestExternalAccountClient(baseWorkloadOptions);
+      const mockAuthHeader = 'Bearer test-access-token';
+      const expectedTrustBoundaryData: TrustBoundaryData = {
+        locations: ['sadad', 'asdad'],
+        encodedLocations: '000x9',
+      };
+      const lookupUrl = WORKLOAD_LOOKUP_ENDPOINT.replace(
+        '{project_id}',
+        encodeURIComponent('12345'),
+      ).replace('{pool_id}', 'my-pool');
+
+      const scope = nock(new URL(lookupUrl).origin)
+        .get(new URL(lookupUrl).pathname)
+        .matchHeader('authorization', mockAuthHeader)
+        .reply(200, expectedTrustBoundaryData);
+
+      const trustBoundary = await client.fetchTrustBoundary(mockAuthHeader);
+
+      assert.deepStrictEqual(trustBoundary, expectedTrustBoundaryData);
+      scope.done();
+    });
+
+    it('fetchTrustBoundary should throw when audience is workload and pool-id is null', async () => {
+      const incorrectWLOptions: BaseExternalAccountClientOptions = {
+        ...baseWorkloadOptions, // Copies all properties from baseWorkforceOptions
+        audience:
+          '//iam.googleapis.com/projects/locations/global/workloadIdentityPools/providers/my-provider', // Overrides the audience property with the new value
+      };
+      const client = new TestExternalAccountClient(incorrectWLOptions);
+      const mockAuthHeader = 'Bearer test-access-token';
+
+      await assert.rejects(
+        client.fetchTrustBoundary(mockAuthHeader),
+        /TrustBoundaryLookup: Failed to fetch trust boundary data due to missing workload pool id or project number/,
       );
     });
   });

--- a/test/test.compute.ts
+++ b/test/test.compute.ts
@@ -18,6 +18,10 @@ import {BASE_PATH, HEADERS, HOST_ADDRESS} from 'gcp-metadata';
 import * as nock from 'nock';
 import * as sinon from 'sinon';
 import {Compute} from '../src';
+import {
+  SERVICE_ACCOUNT_LOOKUP_ENDPOINT,
+  TrustBoundaryData,
+} from '../src/auth/trustboundary';
 
 nock.disableNetConnect();
 
@@ -260,5 +264,65 @@ describe('compute', () => {
     }
 
     assert.fail('failed to throw');
+  });
+
+  describe('trust boundaries', () => {
+    beforeEach(() => {
+      process.env['GOOGLE_AUTH_ENABLE_TRUST_BOUNDARIES'] = 'true';
+    });
+
+    afterEach(() => {
+      delete process.env['GOOGLE_AUTH_ENABLE_TRUST_BOUNDARIES'];
+      sandbox.restore();
+    });
+
+    it('should fetch and return trust boundary data successfully', async () => {
+      //TODO:pjiyer Can this be moved to tb.ts test file?
+      const serviceAccountEmail = 'service-account@example.com';
+      const compute = new Compute({serviceAccountEmail});
+      const mockAuthHeader = 'Bearer test-access-token';
+      const expectedTrustBoundaryData: TrustBoundaryData = {
+        locations: ['sadad', 'asdad'],
+        encodedLocations: '000x9',
+      };
+      const lookupUrl = SERVICE_ACCOUNT_LOOKUP_ENDPOINT.replace(
+        '{service_account_email}',
+        encodeURIComponent(compute.serviceAccountEmail),
+      );
+
+      const scope = nock(new URL(lookupUrl).origin)
+        .get(new URL(lookupUrl).pathname)
+        .matchHeader('authorization', mockAuthHeader)
+        .reply(200, expectedTrustBoundaryData);
+
+      const trustBoundary = await compute.fetchTrustBoundary(mockAuthHeader);
+
+      assert.deepStrictEqual(trustBoundary, expectedTrustBoundaryData);
+      scope.done();
+    });
+
+    it('fetchTrustBoundary should use default if serviceAccountEmail passed in is null', async () => {
+      const compute = new Compute();
+      const mockAuthHeader = 'Bearer test-access-token';
+
+      const lookupUrl = SERVICE_ACCOUNT_LOOKUP_ENDPOINT.replace(
+        '{service_account_email}',
+        encodeURIComponent('default'),
+      );
+
+      const expectedTrustBoundaryData: TrustBoundaryData = {
+        locations: ['sadad', 'asdad'],
+        encodedLocations: '000x9',
+      };
+      const scope = nock(new URL(lookupUrl).origin)
+        .get(new URL(lookupUrl).pathname)
+        .matchHeader('authorization', mockAuthHeader)
+        .reply(200, expectedTrustBoundaryData);
+
+      const trustBoundary = await compute.fetchTrustBoundary(mockAuthHeader);
+
+      assert.deepStrictEqual(trustBoundary, expectedTrustBoundaryData);
+      scope.done();
+    });
   });
 });

--- a/test/test.impersonated.ts
+++ b/test/test.impersonated.ts
@@ -19,6 +19,10 @@ import * as nock from 'nock';
 import {describe, it, afterEach} from 'mocha';
 import {Impersonated, JWT, UserRefreshClient} from '../src';
 import {CredentialRequest} from '../src/auth/credentials';
+import {
+  SERVICE_ACCOUNT_LOOKUP_ENDPOINT,
+  TrustBoundaryData,
+} from '../src/auth/trustboundary';
 
 const PEM_PATH = './test/fixtures/private.pem';
 
@@ -567,5 +571,82 @@ describe('impersonated', () => {
     assert.equal(resp.keyId, expectedKeyID);
     assert.equal(resp.signedBlob, expectedSignedBlob);
     scopes.forEach(s => s.done());
+  });
+
+  describe('trust boundaries', () => {
+    beforeEach(() => {
+      process.env['GOOGLE_AUTH_ENABLE_TRUST_BOUNDARIES'] = 'true';
+    });
+
+    afterEach(() => {
+      delete process.env['GOOGLE_AUTH_ENABLE_TRUST_BOUNDARIES'];
+      nock.cleanAll();
+    });
+
+    it('should fetch and return trust boundary data successfully', async () => {
+      const impersonated = new Impersonated({
+        sourceClient: createSampleJWTClient(),
+        targetPrincipal: 'target@project.iam.gserviceaccount.com',
+        lifetime: 30,
+        targetScopes: ['https://www.googleapis.com/auth/cloud-platform'],
+      });
+
+      const mockAuthHeader = 'Bearer test-access-token';
+      const expectedTrustBoundaryData: TrustBoundaryData = {
+        locations: ['sadad', 'asdad'],
+        encodedLocations: '000x9',
+      };
+      const lookupUrl = SERVICE_ACCOUNT_LOOKUP_ENDPOINT.replace(
+        '{service_account_email}',
+        encodeURIComponent(impersonated.getTargetPrincipal()),
+      );
+
+      const scope = nock(new URL(lookupUrl).origin)
+        .get(new URL(lookupUrl).pathname)
+        .matchHeader('authorization', mockAuthHeader)
+        .reply(200, expectedTrustBoundaryData);
+
+      const trustBoundary =
+        await impersonated.fetchTrustBoundary(mockAuthHeader);
+
+      assert.deepStrictEqual(trustBoundary, expectedTrustBoundaryData);
+      scope.done();
+    });
+
+    it('fetchTrustBoundary should return cache if targetPrincipal passed in is null', async () => {
+      const impersonated = new Impersonated({
+        sourceClient: createSampleJWTClient(),
+        targetPrincipal: undefined,
+        lifetime: 30,
+        targetScopes: ['https://www.googleapis.com/auth/cloud-platform'],
+      });
+      const mockAuthHeader = 'Bearer test-access-token';
+
+      const expectedTrustBoundaryData: TrustBoundaryData = {
+        locations: ['sadad', 'asdad'],
+        encodedLocations: '000x9',
+      };
+      impersonated.trustBoundary = expectedTrustBoundaryData;
+
+      const trustBoundary =
+        await impersonated.fetchTrustBoundary(mockAuthHeader);
+
+      assert.deepStrictEqual(trustBoundary, expectedTrustBoundaryData);
+    });
+
+    it('fetchTrustBoundary should throw if targetPrincipal passed in is null and no cache', async () => {
+      const impersonated = new Impersonated({
+        sourceClient: createSampleJWTClient(),
+        targetPrincipal: undefined,
+        lifetime: 30,
+        targetScopes: ['https://www.googleapis.com/auth/cloud-platform'],
+      });
+      const mockAuthHeader = 'Bearer test-access-token';
+
+      await assert.rejects(
+        impersonated.fetchTrustBoundary(mockAuthHeader),
+        /TrustBoundaryLookup: Failed to fetch trust boundary data due to missing targetPrincipal/,
+      );
+    });
   });
 });

--- a/test/test.jwt.ts
+++ b/test/test.jwt.ts
@@ -1256,7 +1256,7 @@ describe('jwt', () => {
       sandbox.restore();
     });
 
-    it('should return null when GOOGLE_AUTH_ENABLE_TRUST_BOUNDARIES env variable is false/null', async () => {
+    it('fetchTrustBoundary should return null when GOOGLE_AUTH_ENABLE_TRUST_BOUNDARIES env variable is false/null', async () => {
       //TODO:pjiyer can this be moved to tb.ts file?
       process.env['GOOGLE_AUTH_ENABLE_TRUST_BOUNDARIES'] = 'false';
       const jwt = new JWT({
@@ -1271,7 +1271,7 @@ describe('jwt', () => {
       assert.deepStrictEqual(trustBoundary, expectedTrustBoundaryData);
     });
 
-    it('should fetch and return trust boundary data successfully', async () => {
+    it('fetchTrustBoundary should fetch and return trust boundary data successfully', async () => {
       //TODO:pjiyer Can this be moved to tb.ts test file?
       const jwt = new JWT({
         email: 'test@example.iam.gserviceaccount.com',
@@ -1325,7 +1325,7 @@ describe('jwt', () => {
       assert.deepStrictEqual(trustBoundary, expectedTrustBoundaryData);
     });
 
-    it('should not call lookup endpoint in case cachedTrustBoundaries is no-op', async () => {
+    it('fetchTrustBoundary should not call lookup endpoint in case cachedTrustBoundaries is no-op', async () => {
       //TODO:pjiyer Can this be moved to tb.ts test file?
       const jwt = new JWT({
         email: 'test@example.iam.gserviceaccount.com',
@@ -1341,7 +1341,7 @@ describe('jwt', () => {
       assert.deepStrictEqual(trustBoundary, expectedTrustBoundaryData);
     });
 
-    it('should return cached tb in case call to lookup endpoint fails', async () => {
+    it('fetchTrustBoundary should return cached tb in case call to lookup endpoint fails', async () => {
       //TODO:pjiyer Can this be moved to tb.ts test file?
       const jwt = new JWT({
         email: 'test@example.iam.gserviceaccount.com',
@@ -1369,7 +1369,7 @@ describe('jwt', () => {
       scope.done();
     });
 
-    it('should throw in case call to lookup endpoint fails and no cached tb', async () => {
+    it('fetchTrustBoundary should throw in case call to lookup endpoint fails and no cached tb', async () => {
       //TODO:pjiyer Can this be moved to tb.ts test file?
       const jwt = new JWT({
         email: 'test@example.iam.gserviceaccount.com',

--- a/test/test.jwt.ts
+++ b/test/test.jwt.ts
@@ -22,6 +22,11 @@ import * as sinon from 'sinon';
 import {GoogleAuth, JWT} from '../src';
 import {CredentialRequest, JWTInput} from '../src/auth/credentials';
 import * as jwtaccess from '../src/auth/jwtaccess';
+import {
+  NoOpEncodedLocations,
+  SERVICE_ACCOUNT_LOOKUP_ENDPOINT,
+  TrustBoundaryData,
+} from '../src/auth/trustboundary';
 
 function removeBearerFromAuthorizationHeader(headers: Headers): string {
   return (headers.get('authorization') || '').replace('Bearer ', '');
@@ -1238,6 +1243,151 @@ describe('jwt', () => {
       const headers = await jwt.getRequestHeaders(testUri);
       scope.done();
       assert.strictEqual(headers.get('authorization'), want);
+    });
+  });
+
+  describe('trust boundaries', () => {
+    beforeEach(() => {
+      process.env['GOOGLE_AUTH_ENABLE_TRUST_BOUNDARIES'] = 'true';
+    });
+
+    afterEach(() => {
+      delete process.env['GOOGLE_AUTH_ENABLE_TRUST_BOUNDARIES'];
+      sandbox.restore();
+    });
+
+    it('should return null when GOOGLE_AUTH_ENABLE_TRUST_BOUNDARIES env variable is false/null', async () => {
+      //TODO:pjiyer can this be moved to tb.ts file?
+      process.env['GOOGLE_AUTH_ENABLE_TRUST_BOUNDARIES'] = 'false';
+      const jwt = new JWT({
+        email: 'test@example.iam.gserviceaccount.com',
+        key: 'testkey',
+      });
+      const mockAuthHeader = 'Bearer test-access-token';
+      const expectedTrustBoundaryData = null;
+
+      const trustBoundary = await jwt.fetchTrustBoundary(mockAuthHeader);
+
+      assert.deepStrictEqual(trustBoundary, expectedTrustBoundaryData);
+    });
+
+    it('should fetch and return trust boundary data successfully', async () => {
+      //TODO:pjiyer Can this be moved to tb.ts test file?
+      const jwt = new JWT({
+        email: 'test@example.iam.gserviceaccount.com',
+        key: 'testkey',
+      });
+      const mockAuthHeader = 'Bearer test-access-token';
+      const expectedTrustBoundaryData: TrustBoundaryData = {
+        locations: ['sadad', 'asdad'],
+        encodedLocations: '000x9',
+      };
+      const lookupUrl = SERVICE_ACCOUNT_LOOKUP_ENDPOINT.replace(
+        '{service_account_email}',
+        encodeURIComponent(jwt.email!),
+      );
+
+      const scope = nock(new URL(lookupUrl).origin)
+        .get(new URL(lookupUrl).pathname)
+        .matchHeader('authorization', mockAuthHeader)
+        .reply(200, expectedTrustBoundaryData);
+
+      const trustBoundary = await jwt.fetchTrustBoundary(mockAuthHeader);
+
+      assert.deepStrictEqual(trustBoundary, expectedTrustBoundaryData);
+      scope.done();
+    });
+
+    it('fetchTrustBoundary should throw when email is null', async () => {
+      const jwt = new JWT({
+        email: undefined,
+        key: 'testkey',
+      });
+      const mockAuthHeader = 'Bearer test-access-token';
+
+      await assert.rejects(
+        jwt.fetchTrustBoundary(mockAuthHeader),
+        /TrustBoundaryLookup: Failed to fetch trust boundary data due to missing email/,
+      );
+    });
+
+    it('fetchTrustBoundary should return null when default domain is not googleapis.com', async () => {
+      const jwt = new JWT({
+        email: 'test@example.iam.gserviceaccount.com',
+        key: 'testkey',
+        universe_domain: 'abc.com',
+      });
+      const mockAuthHeader = 'Bearer test-access-token';
+      const expectedTrustBoundaryData = null;
+
+      const trustBoundary = await jwt.fetchTrustBoundary(mockAuthHeader);
+
+      assert.deepStrictEqual(trustBoundary, expectedTrustBoundaryData);
+    });
+
+    it('should not call lookup endpoint in case cachedTrustBoundaries is no-op', async () => {
+      //TODO:pjiyer Can this be moved to tb.ts test file?
+      const jwt = new JWT({
+        email: 'test@example.iam.gserviceaccount.com',
+        key: 'testkey',
+      });
+      const mockAuthHeader = 'Bearer test-access-token';
+      const expectedTrustBoundaryData: TrustBoundaryData = {
+        encodedLocations: NoOpEncodedLocations,
+      };
+      jwt.trustBoundary = expectedTrustBoundaryData;
+      const trustBoundary = await jwt.fetchTrustBoundary(mockAuthHeader);
+
+      assert.deepStrictEqual(trustBoundary, expectedTrustBoundaryData);
+    });
+
+    it('should return cached tb in case call to lookup endpoint fails', async () => {
+      //TODO:pjiyer Can this be moved to tb.ts test file?
+      const jwt = new JWT({
+        email: 'test@example.iam.gserviceaccount.com',
+        key: 'testkey',
+      });
+      const mockAuthHeader = 'Bearer test-access-token';
+      const expectedTrustBoundaryData: TrustBoundaryData = {
+        locations: ['sadad', 'asdad'],
+        encodedLocations: '000x9',
+      };
+      jwt.trustBoundary = expectedTrustBoundaryData;
+      const lookupUrl = SERVICE_ACCOUNT_LOOKUP_ENDPOINT.replace(
+        '{service_account_email}',
+        encodeURIComponent(jwt.email!),
+      );
+
+      const scope = nock(new URL(lookupUrl).origin)
+        .get(new URL(lookupUrl).pathname)
+        .matchHeader('authorization', mockAuthHeader)
+        .replyWithError('Call to Lookup endpoint failed');
+
+      const trustBoundary = await jwt.fetchTrustBoundary(mockAuthHeader);
+
+      assert.deepStrictEqual(trustBoundary, expectedTrustBoundaryData);
+      scope.done();
+    });
+
+    it('should throw in case call to lookup endpoint fails and no cached tb', async () => {
+      //TODO:pjiyer Can this be moved to tb.ts test file?
+      const jwt = new JWT({
+        email: 'test@example.iam.gserviceaccount.com',
+        key: 'testkey',
+      });
+      const mockAuthHeader = 'Bearer test-access-token';
+      const lookupUrl = SERVICE_ACCOUNT_LOOKUP_ENDPOINT.replace(
+        '{service_account_email}',
+        encodeURIComponent(jwt.email!),
+      );
+
+      const scope = nock(new URL(lookupUrl).origin)
+        .get(new URL(lookupUrl).pathname)
+        .matchHeader('authorization', mockAuthHeader)
+        .replyWithError('Call to Lookup endpoint failed');
+      ('');
+      await assert.rejects(jwt.fetchTrustBoundary(mockAuthHeader));
+      scope.done();
     });
   });
 });


### PR DESCRIPTION
This change includes trust boundaries for Service Accounts in the google auth nodejs library.

**Impact**
This will allow clients who use the google auth library to also enable trust boundaries ensuring service accounts can access only those resources which are within the trust boundary. We use this [design doc](https://docs.google.com/document/d/1IkRoxRelBF-wUHktFLxKqfcQ2tqAwUg-XcYz_IrVHsQ/edit?resourcekey=0-KdUdpwuLu6eJtcdDb0lISw&tab=t.0#heading=h.17wg41voij6q) as reference for the code changes.

**Testing**
Testing will be added in post initial design review.
