### PR TITLE
feat: add detection for Cloud Run Jobs

### DIFF
--- a/src/auth/envDetect.ts
+++ b/src/auth/envDetect.ts
@@ -20,6 +20,7 @@ export enum GCPEnv {
   CLOUD_FUNCTIONS = 'CLOUD_FUNCTIONS',
   COMPUTE_ENGINE = 'COMPUTE_ENGINE',
   CLOUD_RUN = 'CLOUD_RUN',
+  CLOUD_RUN_JOBS = 'CLOUD_RUN_JOBS',
   NONE = 'NONE',
 }
 
@@ -48,6 +49,8 @@ async function getEnvMemoized(): Promise<GCPEnv> {
       env = GCPEnv.KUBERNETES_ENGINE;
     } else if (isCloudRun()) {
       env = GCPEnv.CLOUD_RUN;
+    } else if (isCloudRunJob()) {
+      env = GCPEnv.CLOUD_RUN_JOBS;
     } else {
       env = GCPEnv.COMPUTE_ENGINE;
     }
@@ -72,6 +75,10 @@ function isCloudFunction() {
  */
 function isCloudRun() {
   return !!process.env.K_CONFIGURATION;
+}
+
+function isCloudRunJob() {
+  return !!process.env.CLOUD_RUN_JOB;
 }
 
 async function isKubernetesEngine() {

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -1449,6 +1449,14 @@ describe('googleauth', () => {
       assert.strictEqual(env, envDetect.GCPEnv.CLOUD_RUN);
     });
 
+    it('should get the current environment if Cloud Run Jobs', async () => {
+      envDetect.clear();
+      mockEnvVar('CLOUD_RUN_JOB', 'KITTY');
+      const {auth} = mockGCE();
+      const env = await auth.getEnv();
+      assert.strictEqual(env, envDetect.GCPEnv.CLOUD_RUN_JOBS);
+    });
+
     it('should make the request via `#fetch`', async () => {
       const url = 'http://example.com';
       const {auth, scopes} = mockGCE();


### PR DESCRIPTION
## Description

This adds detection for Cloud Run Jobs via the `CLOUD_RUN_JOB` env var. This is motivated by bugs like like googleapis/nodejs-logging#1590.

## Impact

Cloud Run Jobs are no longer detected as Compute Engine.

## Testing

Copied Cloud Run Env detection test.

## Checklist

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-auth-library-nodejs/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease
- [ ] Appropriate docs were updated
- [ ] Appropriate comments were added, particularly in complex areas or places that require background
- [ ] No new warnings or issues will be generated from this change

Fixes #2119
