### PR TITLE
Revert "chore(deps): update dependency chai to v6"

### DIFF
--- a/samples/package.json
+++ b/samples/package.json
@@ -22,7 +22,7 @@
     "server-destroy": "^1.0.1"
   },
   "devDependencies": {
-    "chai": "^6.0.0",
+    "chai": "^4.2.0",
     "mocha": "^8.0.0"
   }
 }


### PR DESCRIPTION
Reverts googleapis/google-auth-library-nodejs#2121

Samples tests were failing because of this PR - reverting - we have to stay below Chai 5 until we upgrade node