### PR TITLE
fix: #2139

### DIFF
--- a/src/auth/defaultawssecuritycredentialssupplier.ts
+++ b/src/auth/defaultawssecuritycredentialssupplier.ts
@@ -175,6 +175,9 @@ export class DefaultAwsSecurityCredentialsSupplier
       metadataHeaders,
       context.transporter,
     );
+    if (awsCreds == null || awsCreds.AccessKeyId == null || awsCreds.SecretAccessKey == null || awsCreds.Token == null) {
+      throw new Error("Retrieved invalid aws credentials, expected fields `AccessKeyId`, `SecretAccessKey` and `Token` to be non-null but one or more are null.");
+    }
     return {
       accessKeyId: awsCreds.AccessKeyId,
       secretAccessKey: awsCreds.SecretAccessKey,
@@ -243,6 +246,9 @@ export class DefaultAwsSecurityCredentialsSupplier
       ...this.additionalGaxiosOptions,
       url: `${this.securityCredentialsUrl}/${roleName}`,
       headers: headers,
+      // NOTE: Do not remove this. AWS returns `Content-Type: text/plain` even though
+      // the response is a json, so it is necessary to have this.
+      responseType: 'json'
     } as GaxiosOptions;
     AuthClient.setMethodName(opts, '#retrieveAwsSecurityCredentials');
     const response =


### PR DESCRIPTION
## Description
Given that the AWS API (called https://github.com/googleapis/google-auth-library-nodejs/blob/main/src/auth/defaultawssecuritycredentialssupplier.ts#L250) returns a JSON body with the correct tokens, but with a Content-Type of `text/plain` instead of `application/json` and given that the gaxios call no longer specifies a responseType (https://github.com/googleapis/google-auth-library-nodejs/blob/main/src/auth/defaultawssecuritycredentialssupplier.ts#L245), gaxios tries to infer the return type from the header (`text/plain`), therefore simply returning a string instead of a object.

The function calling this method to get the credential, assumes that the response is an object though, accessing fields such as `awsCreds.AccessKeyId` (https://github.com/googleapis/google-auth-library-nodejs/blob/main/src/auth/defaultawssecuritycredentialssupplier.ts#L178), which evaluate to undefined, as the properties do not exist on a String.

The rest of the code seems to assume that if an object is returned and no error is thrown, that the fields are correctly set and do not further validate anything. This leads to further API calls that rely on these values to simply use them, without validating if they are set, resulting in downstream errors.

This patch fixes this, by setting the `responseType` back to `json` (which it used to be set to) meaning that gaxios will try to parse it as a json object, even if the Content-Type header is `text/plain` and adding an explicit validation that the corresponding fields exist, throwing an error if they do not.

## Impact
If the response from the AWS Security Credentials API is invalid, it will throw an error.

## Testing
No tests were added or changed. A test would need to be run on an AWS EC2 instance that is configured for Workload Identity Federation with a Google Cloud Project to run and cannot be run using the current setup (to my knowledge).

## Additional Information
None

## Checklist

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-auth-library-nodejs/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease
- [x] Appropriate docs were updated
- [x] Appropriate comments were added, particularly in complex areas or places that require background
- [x] No new warnings or issues will be generated from this change

Fixes googleapis/google-cloud-node-core#500 🦕