### PR TITLE
fix: export ExternalAccountAuthorizedUserCredential

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,11 @@ export {
   PluggableAuthClientOptions,
   ExecutableError,
 } from './auth/pluggable-auth-client';
+export {
+  EXTERNAL_ACCOUNT_AUTHORIZED_USER_TYPE,
+  ExternalAccountAuthorizedUserClient,
+  ExternalAccountAuthorizedUserClientOptions,
+} from './auth/externalAccountAuthorizedUserClient';
 export {PassThroughClient} from './auth/passthrough';
 
 type ALL_EXPORTS = (typeof import('./'))[keyof typeof import('./')];


### PR DESCRIPTION
Fixing exporting the src/auth/externalAccountAuthorizedUserClient.ts so users can import it.