### PR TITLE
feat: Support scopes from impersonated JSON

### DIFF
--- a/src/auth/credentials.ts
+++ b/src/auth/credentials.ts
@@ -84,6 +84,7 @@ export interface ImpersonatedJWTInput {
   source_credentials?: JWTInput;
   service_account_impersonation_url?: string;
   delegates?: string[];
+  scopes?: string[];
 }
 
 export interface CredentialBody {

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -710,7 +710,8 @@ export class GoogleAuth<T extends AuthClient = AuthClient> {
       );
     }
 
-    const targetScopes = this.getAnyScopes() ?? [];
+    const targetScopes =
+      (this.scopes || json.scopes || this.defaultScopes) ?? [];
 
     return new Impersonated({
       ...json,

--- a/test/fixtures/impersonated-with-scopes.json
+++ b/test/fixtures/impersonated-with-scopes.json
@@ -1,0 +1,13 @@
+{
+  "type": "impersonated_service_account",
+  "source_credentials": {
+    "client_id": "oauth_client_id",
+    "client_secret": "oauth_client_secret",
+    "refresh_token": "user_refresh_token",
+    "type": "authorized_user"
+  },
+  "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/service-account-email@project-name.iam.gserviceaccount.com:generateAccessToken",
+  "scopes": [
+    "https://www.googleapis.com/auth/drive"
+  ]
+}


### PR DESCRIPTION
## Description

`scopes` field is a recent addition to the impersonated credential json. Example JSON:
```
{
  "delegates": [],
  "scopes": [
    "https://www.googleapis.com/auth/drive"
  ],
  "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/service-account-email@project-name.iam.gserviceaccount.com:generateAccessToken",
  "source_credentials": {
    "client_id": "oauth_client_id",
    "client_secret": "oauth_client_secret",
    "refresh_token": "user_refresh_token",
    "type": "authorized_user",
    "universe_domain": "googleapis.com"
  },
  "type": "impersonated_service_account"
}
```
This json is generated from `gcloud auth application-default login --impersonate-service-account <sa_email> --scopes <list of scopes>`.

When user generates a json with scopes, they expect it to be used for the impersonated token, unless a different scope is requested through code.

## Impact

`scopes` field will be honored.


## Testing

Unit tests added for coverage


## Checklist

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-auth-library-nodejs/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease
- [ ] Appropriate docs were updated
- [ ] Appropriate comments were added, particularly in complex areas or places that require background
- [ ] No new warnings or issues will be generated from this change

Fixes #issue_number_goes_here 🦕
